### PR TITLE
Compliance: handle images length

### DIFF
--- a/mkdocs_rss_plugin/templates/rss.xml.jinja2
+++ b/mkdocs_rss_plugin/templates/rss.xml.jinja2
@@ -41,7 +41,7 @@
       <pubDate>{{ item.pubDate }}</pubDate>
       <source url="{{ feed.rss_url }}">{{ feed.title }}</source>
       <guid isPermaLink="true">{{ item.link }}</guid>
-      {% if item.image is defined %}<enclosure url="{{ item.image[0] }}" type="{{ item.image[1] }}" />{% endif %}
+      {% if item.image is defined %}<enclosure url="{{ item.image[0] }}" type="{{ item.image[1] }}" length="{{ item.image[2] }}" />{% endif %}
     </item>
     {% endfor %}
   </channel>

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -46,6 +46,20 @@ class Util:
         # Checks if user is running builds on CI and raise appropriate warnings
         CiHandler(git_repo.git).raise_ci_warnings()
 
+    def build_local_path(self, page_path: str, path_to_append: str) -> str:
+        """Build URL using base URL, cumulating existing and passed path, \
+        then adding URL arguments.
+
+        :param page_path: base URL with existing path to use
+        :type base_url: str
+        :param path: URL path to cumulate with existing
+        :type path: str
+
+        :return: complete and valid path
+        :rtype: str
+        """
+        return str(Path(page_path).parent / Path(path_to_append))
+
     def build_url(self, base_url: str, path: str, args_dict: dict = None) -> str:
         """Build URL using base URL, cumulating existing and passed path, \
         then adding URL arguments.


### PR DESCRIPTION
As spotted in #9, image's length is missing to perfectly comply with RSS specification about enclosures.

With this PR:

- determine if referenced image in meta tags is local or remote
- if local, use `pathlib.path.stat().st_size()` to get content length
- if remote, perform a HTTP request:
  - a HEAD request is performed
  - if failing, a GET request is performed with disabled SSL verification
  - if still failing --> `None`
- the calculated length is added into the final XML

Close #9.