### PR TITLE
Handle special characters and different cases

### DIFF
--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -83,7 +83,7 @@ class GitRssPlugin(BasePlugin):
             "description": config.get("site_description", None),
             "entries": [],
             "generator": "{} - v{}".format(__title__, __version__),
-            "html_url": config.get("site_url", __uri__),
+            "html_url": self.util.get_site_url(config),
             "language": self.util.guess_locale(config),
             "pubDate": formatdate(get_build_timestamp()),
             "repo_url": config.get("repo_url", config.get("site_url", None)),
@@ -100,22 +100,21 @@ class GitRssPlugin(BasePlugin):
         self.feed_updated = deepcopy(base_feed)
 
         # final feed url
-        if config.get("site_url"):
-            # handle trailing slash
-            if not config.get("site_url").endswith("/"):
-                site_url_base = config.get("site_url") + "/"
-            else:
-                site_url_base = config.get("site_url")
-
+        if base_feed.get("html_url"):
             # concatenate both URLs
-            self.feed_created["rss_url"] = site_url_base + OUTPUT_FEED_CREATED
-            self.feed_updated["rss_url"] = site_url_base + OUTPUT_FEED_UPDATED
+            self.feed_created["rss_url"] = (
+                base_feed.get("html_url") + OUTPUT_FEED_CREATED
+            )
+            self.feed_updated["rss_url"] = (
+                base_feed.get("html_url") + OUTPUT_FEED_UPDATED
+            )
         else:
             logging.warning(
                 "[rss-plugin] The variable `site_url` is not set in the MkDocs "
                 "configuration file whereas a URL is mandatory to publish. "
                 "See: https://validator.w3.org/feed/docs/rss2.html#requiredChannelElements"
             )
+            self.feed_created["rss_url"] = self.feed_updated["rss_url"] = None
 
         # ending event
         return config

--- a/mkdocs_rss_plugin/templates/rss.xml.jinja2
+++ b/mkdocs_rss_plugin/templates/rss.xml.jinja2
@@ -4,16 +4,16 @@
   xmlns:dc="https://purl.org/dc/elements/1.1/">
   <channel>
     <!-- Mandatory elements -->
-    <description>{{ feed.description|e }}</description>
-    <title>{{ feed.title|e }}</title>
-    <link>{{ feed.html_url }}</link>
-    <atom:link href="{{ feed.rss_url }}" rel="self" type="application/rss+xml" />
+    {% if feed.title is not none %}<title>{{ feed.title|e }}</title>{% endif %}
+    {% if feed.description is not none %}<description>{{ feed.description|e }}</description>{% endif %}
+    {% if feed.html_url is not none %}<link>{{ feed.html_url }}</link>{% endif %}
+    {% if feed.rss_url is not none %}<atom:link href="{{ feed.rss_url }}" rel="self" type="application/rss+xml" />{% endif %}
 
     <!-- Optional elements -->
-    {% if feed.author is defined %}<managingEditor>{{ feed.author }}</managingEditor>{% endif %}
-    {% if feed.category is defined %}<category>{{ feed.category }}</category>{% endif %}
-    {% if feed.repo_url is defined %}<docs>{{ feed.repo_url }}</docs>{% endif %}
-    {% if feed.language is defined %}<language>{{ feed.language }}</language>{% endif %}
+    {% if feed.author is not none %}<managingEditor>{{ feed.author }}</managingEditor>{% endif %}
+    {% if feed.category is not none %}<category>{{ feed.category }}</category>{% endif %}
+    {% if feed.repo_url is not none %}<docs>{{ feed.repo_url }}</docs>{% endif %}
+    {% if feed.language is not none %}<language>{{ feed.language }}</language>{% endif %}
 
     <!-- Timestamps and frequency -->
     <pubDate>{{ feed.pubDate }}</pubDate>
@@ -28,7 +28,7 @@
     <image>
       <url>{{ feed.logo_url }}</url>
       <title>{{ feed.title }} - Illustration</title>
-      <link>{{ feed.html_url }}</link>
+      {% if feed.html_url is not none %}<link>{{ feed.html_url }}</link>{% endif %}
     </image>
     {% endif %}
 
@@ -37,10 +37,10 @@
     <item>
       <title>{{ item.title|e }}</title>
       <description>{{ item.description|e }}</description>
-      <link>{{ item.link }}</link>
+      {% if item.link is not none %}<link>{{ item.link }}</link>{% endif %}
       <pubDate>{{ item.pubDate }}</pubDate>
-      <source url="{{ feed.rss_url }}">{{ feed.title }}</source>
-      <guid isPermaLink="true">{{ item.link }}</guid>
+      {% if item.link is not none %}<source url="{{ feed.rss_url }}">{{ feed.title }}</source>{% endif %}
+      {% if item.link is not none %}<guid isPermaLink="true">{{ item.link }}</guid>{% endif %}
       {% if item.image is not none %}
       <enclosure url="{{ item.image[0] }}" type="{{ item.image[1] }}" length="{{ item.image[2] }}" />
       {% endif %}

--- a/mkdocs_rss_plugin/templates/rss.xml.jinja2
+++ b/mkdocs_rss_plugin/templates/rss.xml.jinja2
@@ -4,8 +4,8 @@
   xmlns:dc="https://purl.org/dc/elements/1.1/">
   <channel>
     <!-- Mandatory elements -->
-    <title>{{ feed.title }}</title>
     <description>{{ feed.description|e }}</description>
+    <title>{{ feed.title|e }}</title>
     <link>{{ feed.html_url }}</link>
     <atom:link href="{{ feed.rss_url }}" rel="self" type="application/rss+xml" />
 
@@ -35,7 +35,7 @@
     <!-- Entries -->
     {% for item in feed.entries %}
     <item>
-      <title>{{ item.title }}</title>
+      <title>{{ item.title|e }}</title>
       <description>{{ item.description|e }}</description>
       <link>{{ item.link }}</link>
       <pubDate>{{ item.pubDate }}</pubDate>

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -267,25 +267,52 @@ class Util:
         return img_length
 
     @staticmethod
-    def guess_locale(config: Config) -> str or None:
+    def get_site_url(mkdocs_config: Config) -> str or None:
+        """Extract site URL from MkDocs configuration and enforce the behavior to ensure \
+        returning a str with length > 0 or None. If exists, it adds an ending slash.
+
+        :param mkdocs_config: configuration object
+        :type mkdocs_config: Config
+
+        :return: site url
+        :rtype: str or None
+        """
+        # this method exists because the following line returns an empty string instead of \
+        # None (because the key alwayus exists)
+        defined_site_url = mkdocs_config.get("site_url", None)
+
+        # cases
+        if defined_site_url is None or not len(defined_site_url):
+            # in cas of mkdocs's behavior change
+            site_url = None
+        else:
+            site_url = defined_site_url
+            # handle trailing slash
+            if not site_url.endswith("/"):
+                site_url = site_url + "/"
+
+        return site_url
+
+    @staticmethod
+    def guess_locale(mkdocs_config: Config) -> str or None:
         """Extract language code from MkDocs or Theme configuration.
 
-        :param config: configuration object
-        :type config: Config
+        :param mkdocs_config: configuration object
+        :type mkdocs_config: Config
 
         :return: language code
         :rtype: str or None
         """
         # MkDocs locale settings - might be added in future mkdocs versions
         # see: https://github.com/timvink/mkdocs-git-revision-date-localized-plugin/issues/24
-        if config.get("locale"):
-            return config.get("locale")
+        if mkdocs_config.get("locale"):
+            return mkdocs_config.get("locale")
 
         # Some themes implement a locale or a language setting
-        if "theme" in config and "locale" in config.get("theme"):
-            return config.get("theme")._vars.get("locale")
-        elif "theme" in config and "language" in config.get("theme"):
-            return config.get("theme")._vars.get("language")
+        if "theme" in mkdocs_config and "locale" in mkdocs_config.get("theme"):
+            return mkdocs_config.get("theme")._vars.get("locale")
+        elif "theme" in mkdocs_config and "language" in mkdocs_config.get("theme"):
+            return mkdocs_config.get("theme")._vars.get("language")
         else:
             return None
 


### PR DESCRIPTION
- enable auto-escape on feed and item titles, using the [Jinja `e` filter](https://jinja.palletsprojects.com/en/2.11.x/templates/#working-with-manual-escaping) - #19
- improve consistency for missing attributes in mkdocs.yml, returning almost always a `None` value