### PR TITLE
Feed XML output improvments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ----
 
+## 0.11.0
+
+### Added
+
+- option to prettify the output, disabling minify. See [issue #18](https://github.com/Guts/mkdocs-rss-plugin/issues/18), [PR #33](https://github.com/Guts/mkdocs-rss-plugin/pull/33) and [related documentation section](https://guts.github.io/mkdocs-rss-plugin/configuration/#prettified-output)
+
+### Changed
+
+- By default, the output file is now minified.
+
+----
+
 ## 0.10.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,13 +18,14 @@ Typical `mkdocs.yml`:
 plugins:
   - rss:
       abstract_chars_count: 160
-      feed_ttl: 1440
-      length: 20
       date_from_meta:
         as_creation: "date"
         as_update: false
         datetime_format: "%Y-%m-%d %H:%M"
+      feed_ttl: 1440
       image: https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png
+      length: 20
+      pretty_print: false
 ```
 
 For further information, [see the user documentation](https://guts.github.io/mkdocs-rss-plugin/).

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -52,16 +52,7 @@ Basically, each page is an item element in the RSS feed.
 
 ## Plugin options
 
-Sample:
-
-```yaml
-plugins:
-  - rss:
-      abstract_chars_count: 150
-      feed_ttl: 1440
-      image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png'
-      length: 20
-```
+For a sample see [homepage](/#usage).
 
 ### Channel image
 
@@ -157,6 +148,18 @@ At the end, into the RSS you will get:
 
 </item>
 ```
+
+### Prettified output
+
+By default, the output file is minified, using Jinja2 strip options and manual work. It's possible to disable it and prettify the output using `pretty_print: true`.
+
+```yaml
+plugins:
+  - rss:
+      pretty_print: true
+```
+
+Default: `False`.
 
 ----
 

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -9,10 +9,10 @@ image: "rss_icon.svg"
 
 Here come the feeds generated for this documentation:
 
-- [feed_rss_created.xml](feed_rss_created.xml) for  latest **created** pages
-- [feed_rss_updated.xml](feed_rss_updated.xml) for latest **updated** pages
+- [feed_rss_created.xml](feed_rss_created.xml) for  latest **created** pages: [W3C validator](https://validator.w3.org/feed/check.cgi?url=https%3A//guts.github.io/mkdocs-rss-plugin/feed_rss_created.xml)
+- [feed_rss_updated.xml](feed_rss_updated.xml) for latest **updated** pages: [W3C validator](https://validator.w3.org/feed/check.cgi?url=https%3A//guts.github.io/mkdocs-rss-plugin/feed_rss_updated.xml)
 
-Or displayed as a Feedly follow button:
+Or it could be displayed as a Feedly follow button:
 
 [![Feedly button](https://s3.feedly.com/img/follows/feedly-follow-rectangle-flat-big_2x.png "Follow us on Feedly"){: width=130 height= 50 loading=lazy }](https://feedly.com/i/subscription/feed%2Fhttps%3A%2F%2Fguts.github.io%2Fmkdocs-rss-plugin%2Ffeed_rss_created.xml)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ plugins:
         as_update: false
         datetime_format: "%Y-%m-%d %H:%M"
       image: https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png
+      pretty_print: false
   - search
 
 theme:

--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -223,8 +223,10 @@ class GitRssPlugin(BasePlugin):
         )
         # load Jinja environment
         env = Environment(
-            loader=FileSystemLoader(self.tpl_folder),
             autoescape=select_autoescape(["html", "xml"]),
+            loader=FileSystemLoader(self.tpl_folder),
+            lstrip_blocks=True,
+            trim_blocks=True,
         )
 
         template = env.get_template(self.tpl_file.name)

--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -233,7 +233,23 @@ class GitRssPlugin(BasePlugin):
 
         # write feeds to files
         with out_feed_created.open(mode="w", encoding="UTF8") as fifeed_created:
-            fifeed_created.write(template.render(feed=self.feed_created))
+            prev_char = ""
+            for char in template.render(feed=self.feed_created):
+                if char == "\n":
+                    continue
+                if char == " " and prev_char == " ":
+                    prev_char = char
+                    continue
+                prev_char = char
+                fifeed_created.write(char)
 
         with out_feed_updated.open(mode="w", encoding="UTF8") as fifeed_updated:
-            fifeed_updated.write(template.render(feed=self.feed_updated))
+            for char in template.render(feed=self.feed_updated):
+                if char == "\n":
+                    prev_char = char
+                    continue
+                if char == " " and prev_char == " ":
+                    prev_char = char
+                    continue
+                prev_char = char
+                fifeed_updated.write(char)

--- a/mkdocs_rss_plugin/templates/rss.xml.jinja2
+++ b/mkdocs_rss_plugin/templates/rss.xml.jinja2
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<rss version="2.0"
-  xmlns:atom="https://www.w3.org/2005/Atom"
-  xmlns:dc="https://purl.org/dc/elements/1.1/"
-  xmlns:webfeeds="http://webfeeds.org/rss/1.0"
-  >
-
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
   <channel>
     {# Mandatory elements #}
     {% if feed.title is not none %}<title>{{ feed.title|e }}</title>{% endif %}

--- a/mkdocs_rss_plugin/templates/rss.xml.jinja2
+++ b/mkdocs_rss_plugin/templates/rss.xml.jinja2
@@ -6,27 +6,27 @@
   >
 
   <channel>
-    <!-- Mandatory elements -->
+    {# Mandatory elements #}
     {% if feed.title is not none %}<title>{{ feed.title|e }}</title>{% endif %}
     {% if feed.description is not none %}<description>{{ feed.description|e }}</description>{% endif %}
     {% if feed.html_url is not none %}<link>{{ feed.html_url }}</link>{% endif %}
     {% if feed.rss_url is not none %}<atom:link href="{{ feed.rss_url }}" rel="self" type="application/rss+xml" />{% endif %}
 
-    <!-- Optional elements -->
+    {# Optional elements #}
     {% if feed.author is not none %}<managingEditor>{{ feed.author }}</managingEditor>{% endif %}
     {% if feed.category is not none %}<category>{{ feed.category }}</category>{% endif %}
     {% if feed.repo_url is not none %}<docs>{{ feed.repo_url }}</docs>{% endif %}
     {% if feed.language is not none %}<language>{{ feed.language }}</language>{% endif %}
 
-    <!-- Timestamps and frequency -->
+    {# Timestamps and frequency #}
     <pubDate>{{ feed.pubDate }}</pubDate>
     <lastBuildDate>{{ feed.buildDate }}</lastBuildDate>
     <ttl>{{ feed.ttl }}</ttl>
 
-    <!-- Credits -->
+    {# Credits #}
     <generator>{{ feed.generator }}</generator>
 
-    <!-- Feed illustration -->
+    {# Feed illustration #}
     {% if feed.logo_url is defined %}
     <image>
       <url>{{ feed.logo_url }}</url>
@@ -35,7 +35,7 @@
     </image>
     {% endif %}
 
-    <!-- Entries -->
+    {# Entries #}
     {% for item in feed.entries %}
     <item>
       <title>{{ item.title|e }}</title>

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,6 +60,7 @@ class TestConfig(unittest.TestCase):
             "feed_ttl": 1440,
             "image": None,
             "length": 20,
+            "pretty_print": False,
         }
 
         # load
@@ -78,6 +79,7 @@ class TestConfig(unittest.TestCase):
             "feed_ttl": 1440,
             "image": self.feed_image,
             "length": 20,
+            "pretty_print": False,
         }
 
         # custom config


### PR DESCRIPTION
# Main changes

Add an option `pretty_print` to restore former behavior and prevent eventual side-effects.

Close #18 

## Minified (new default behavior)

```xml
<?xml version="1.0" encoding="UTF-8" ?><rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/"> <channel><title>MkDocs RSS Plugin</title><description>Documentation about the MkDocs RSS Plugin</description><link>https://guts.github.io/mkdocs-rss-plugin/</link><atom:link href="https://guts.github.io/mkdocs-rss-plugin/feed_rss_created.xml" rel="self" type="application/rss+xml" /><managingEditor>dev@ingeoveritas.com (Julien M.)</managingEditor><docs>https://github.com/guts/mkdocs-rss-plugin/</docs><language>en</language> <pubDate>Tue, 05 Jan 2021 12:03:26 -0000</pubDate> <lastBuildDate>Tue, 05 Jan 2021 12:03:26 -0000</lastBuildDate> <ttl>1440</ttl> <generator>MkDocs RSS plugin - v0.10.0</generator> <image> <url>https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png</url> <title>MkDocs RSS Plugin</title><link>https://guts.github.io/mkdocs-rss-plugin/</link> </image> <item> <title>Settings</title> <description>Configuration steps and settings for MkDocs RSS plugin</description><link>https://guts.github.io/mkdocs-rss-plugin/configuration/</link> <pubDate>Thu, 31 Dec 2020 13:20:00 -0000</pubDate><source url="https://guts.github.io/mkdocs-rss-plugin/feed_rss_created.xml">MkDocs RSS Plugin</source><guid isPermaLink="true">https://guts.github.io/mkdocs-rss-plugin/configuration/</guid> <enclosure url="https://svgsilh.com/png-512/97849.png" type="image/png" length="19753" /> </item> <item> <title>Changelog</title> <description>Changelog of the RSS plugin for MkDocs.</description><link>https://guts.github.io/mkdocs-rss-plugin/changelog/</link> <pubDate>Thu, 22 Oct 2020 17:18:38 -0000</pubDate><source url="https://guts.github.io/mkdocs-rss-plugin/feed_rss_created.xml">MkDocs RSS Plugin</source><guid isPermaLink="true">https://guts.github.io/mkdocs-rss-plugin/changelog/</guid> </item> <item> <title>Home</title> <description>MkDocs RSS plugin: generate RSS feeds for your static website using git log.</description><link>https://guts.github.io/mkdocs-rss-plugin/</link> <pubDate>Sun, 05 Jul 2020 22:00:00 -0000</pubDate><source url="https://guts.github.io/mkdocs-rss-plugin/feed_rss_created.xml">MkDocs RSS Plugin</source><guid isPermaLink="true">https://guts.github.io/mkdocs-rss-plugin/</guid> <enclosure url="https://guts.github.io/mkdocs-rss-plugin/rss_icon.svg" type="image/svg+xml" length="1109" /> </item> </channel></rss>
```
Size: 2.4 kB

## Prettified (former default behavior)

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
  <channel>
    
    <title>MkDocs RSS Plugin</title>
    <description>Documentation about the MkDocs RSS Plugin</description>
    <link>https://guts.github.io/mkdocs-rss-plugin/</link>
    <atom:link href="https://guts.github.io/mkdocs-rss-plugin/feed_rss_created.xml" rel="self" type="application/rss+xml" />

    
    <managingEditor>dev@ingeoveritas.com (Julien M.)</managingEditor>
    
    <docs>https://github.com/guts/mkdocs-rss-plugin/</docs>
    <language>en</language>

    
    <pubDate>Tue, 05 Jan 2021 12:01:50 -0000</pubDate>
    <lastBuildDate>Tue, 05 Jan 2021 12:01:50 -0000</lastBuildDate>
    <ttl>1440</ttl>

    
    <generator>MkDocs RSS plugin - v0.10.0</generator>

    
    
    <image>
      <url>https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png</url>
      <title>MkDocs RSS Plugin</title>
      <link>https://guts.github.io/mkdocs-rss-plugin/</link>
    </image>
    

    
    
    <item>
      <title>Settings</title>
      <description>Configuration steps and settings for MkDocs RSS plugin</description>
      <link>https://guts.github.io/mkdocs-rss-plugin/configuration/</link>
      <pubDate>Thu, 31 Dec 2020 13:20:00 -0000</pubDate>
      <source url="https://guts.github.io/mkdocs-rss-plugin/feed_rss_created.xml">MkDocs RSS Plugin</source>
      <guid isPermaLink="true">https://guts.github.io/mkdocs-rss-plugin/configuration/</guid>
      
      <enclosure url="https://svgsilh.com/png-512/97849.png" type="image/png" length="19753" />
      
    </item>
    
    <item>
      <title>Changelog</title>
      <description>Changelog of the RSS plugin for MkDocs.</description>
      <link>https://guts.github.io/mkdocs-rss-plugin/changelog/</link>
      <pubDate>Thu, 22 Oct 2020 17:18:38 -0000</pubDate>
      <source url="https://guts.github.io/mkdocs-rss-plugin/feed_rss_created.xml">MkDocs RSS Plugin</source>
      <guid isPermaLink="true">https://guts.github.io/mkdocs-rss-plugin/changelog/</guid>
      
    </item>
    
    <item>
      <title>Home</title>
      <description>MkDocs RSS plugin: generate RSS feeds for your static website using git log.</description>
      <link>https://guts.github.io/mkdocs-rss-plugin/</link>
      <pubDate>Sun, 05 Jul 2020 22:00:00 -0000</pubDate>
      <source url="https://guts.github.io/mkdocs-rss-plugin/feed_rss_created.xml">MkDocs RSS Plugin</source>
      <guid isPermaLink="true">https://guts.github.io/mkdocs-rss-plugin/</guid>
      
      <enclosure url="https://guts.github.io/mkdocs-rss-plugin/rss_icon.svg" type="image/svg+xml" length="1109" />
      
    </item>
    
  </channel>
</rss>
```

Size: 2.8 kB

# Others

- remove webfeed namespace
- use http instead of https for namespaces to be perfectly compliant with validators
- use jinja comments instead of html syntax