### PR TITLE
Retrieve author or authors from page.meta

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -1,5 +1,6 @@
 ---
 title: Configuration
+author: "Julien Moura"
 date: 2020-12-31 14:20
 description: Configuration steps and settings for MkDocs RSS plugin
 image: "https://svgsilh.com/png-512/97849.png"

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,5 +1,6 @@
 ---
 title: The MkDocs RSS Plugin
+authors: ["Julien Moura", "Tim Vink"]
 date: 2020-07-06
 description: "MkDocs RSS plugin: generate RSS feeds for your static website using git log."
 image: "rss_icon.svg"

--- a/mkdocs_rss_plugin/customtypes.py
+++ b/mkdocs_rss_plugin/customtypes.py
@@ -15,6 +15,7 @@ from typing import NamedTuple
 # ##################################
 class PageInformation(NamedTuple):
     abs_path: Path = None
+    authors: tuple = None
     created: datetime = None
     updated: datetime = None
     title: str = None

--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -177,6 +177,7 @@ class GitRssPlugin(BasePlugin):
         self.pages_to_filter.append(
             PageInformation(
                 abs_path=Path(page.file.abs_src_path),
+                authors=self.util.get_authors_from_meta(in_page=page),
                 created=page_dates[0],
                 updated=page_dates[1],
                 title=page.title,

--- a/mkdocs_rss_plugin/templates/rss.xml.jinja2
+++ b/mkdocs_rss_plugin/templates/rss.xml.jinja2
@@ -34,6 +34,12 @@
     {% for item in feed.entries %}
     <item>
       <title>{{ item.title|e }}</title>
+      {# Authors loop #}
+      {% if item.authors is not none %}
+        {% for author in item.authors %}
+      <author>{{ author }}</author>
+        {% endfor %}
+      {% endif %}
       <description>{{ item.description|e }}</description>
       {% if item.link is not none %}<link>{{ item.link }}</link>{% endif %}
       <pubDate>{{ item.pubDate }}</pubDate>

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -188,6 +188,44 @@ class Util:
                 get_build_timestamp(),
             )
 
+    def get_authors_from_meta(self, in_page: Page) -> Tuple[str] or None:
+        """Returns authors from page meta. It handles 'author' and 'authors' for keys, \
+        str and iterable as values types.
+
+        Args:
+            in_page (Page): page to look at
+
+        Returns:
+            Tuple[str]: tuple of authors names
+        """
+        # identify the key
+        if "author" in in_page.meta:
+            if isinstance(in_page.meta.get("author"), str):
+                return (in_page.meta.get("author"),)
+            elif isinstance(in_page.meta.get("author"), (list, tuple)):
+                return tuple(in_page.meta.get("author"))
+            else:
+                logging.warning(
+                    "[rss-plugin] Type of author value in page.meta (%s) is not valid. "
+                    "It should be str, list or tuple, not: %s."
+                    % in_page.file.abs_src_path,
+                    type(in_page.meta.get("author")),
+                )
+                return None
+        elif "authors" in in_page.meta:
+            if isinstance(in_page.meta.get("authors"), str):
+                return (in_page.meta.get("authors"),)
+            elif isinstance(in_page.meta.get("authors"), (list, tuple)):
+                return tuple(in_page.meta.get("authors"))
+            else:
+                logging.warning(
+                    "[rss-plugin] Type of authors value in page.meta (%s) is not valid. "
+                    "It should be str, list or tuple, not: %s."
+                    % in_page.file.abs_src_path,
+                    type(in_page.meta.get("authors")),
+                )
+                return None
+
     def get_date_from_meta(
         self, date_metatag_value: str, meta_datetime_format: str
     ) -> float:
@@ -420,6 +458,7 @@ class Util:
         )[:length]:
             filtered_pages.append(
                 {
+                    "authors": page.authors,
                     "description": page.description,
                     "link": page.url_full,
                     "pubDate": formatdate(getattr(page, attribute)),


### PR DESCRIPTION
Closes #34.

Retrieve git contributors will arrive in a next step.