### PR TITLE
fix: Completely skip pages excluded by match_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,6 +184,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+# JetBrains project settings
+.idea
+
 # mkdocs documentation
 /site
 

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -173,7 +173,7 @@ plugins:
       match_path: "blog/.*"
 ```
 
-Default: `None`.
+Default: `.*`.
 
 ----
 

--- a/mkdocs_rss_plugin/customtypes.py
+++ b/mkdocs_rss_plugin/customtypes.py
@@ -22,4 +22,3 @@ class PageInformation(NamedTuple):
     description: str = None
     image: str = None
     url_full: str = None
-    src_path: str = None

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -6,7 +6,6 @@
 
 # standard library
 import logging
-import re
 import ssl
 from datetime import date, datetime
 from email.utils import formatdate
@@ -458,7 +457,7 @@ class Util:
             return None
 
     @staticmethod
-    def filter_pages(pages: list, attribute: str, length: int, match_path: str) -> list:
+    def filter_pages(pages: list, attribute: str, length: int) -> list:
         """Filter and return pages into a friendly RSS structure.
 
         :param pages: pages to filter
@@ -472,12 +471,9 @@ class Util:
         :rtype: list
         """
         filtered_pages = []
-        path_pattern = re.compile(match_path) if match_path else None
         for page in sorted(
             pages, key=lambda page: getattr(page, attribute), reverse=True
         )[:length]:
-            if path_pattern and not path_pattern.match(page.src_path):
-                continue
             filtered_pages.append(
                 {
                     "authors": page.authors,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,7 +58,7 @@ class TestConfig(unittest.TestCase):
             "image": None,
             "length": 20,
             "pretty_print": False,
-            "match_path": None,
+            "match_path": ".*",
         }
 
         # load
@@ -78,7 +78,7 @@ class TestConfig(unittest.TestCase):
             "image": self.feed_image,
             "length": 20,
             "pretty_print": False,
-            "match_path": None,
+            "match_path": ".*",
         }
 
         # custom config


### PR DESCRIPTION
I was experimenting @rmorshea's great contribution on #43 to include only a small subset of relevant pages in the feeds for my site, hoping that it would be an elegant way to overcome the limitation in #23. However, I noticed the following:

- The plugin was still outputting warnings because it failed to obtain the correct Git dates from pages that I was excluding with `match_path`
- None of the pages that I was including with `match_path` would show up on the output

This was because the `match_path` filter was only being applied during the `on_post_build` event handler, and [after the list of pages to include in the output had already been truncated](https://github.com/Guts/mkdocs-rss-plugin/blob/master/mkdocs_rss_plugin/util.py#L479-L480) by the configuration `length`.

To fix this issue I propose that we completely skip processing the pages that aren't included in `match_path`, with the additional advantages:

- On bigger sites, there is a potential performance improvement if you only need RSS feeds for a small subset of pages. The version that I'm proposing completely skips processing for pages that aren't to be included in the output as soon as possible, and also [compiles the regex pattern only once to be reused](https://docs.python.org/3/library/re.html#re.compile) on the pages that are included.
- This solution is more self-contained since the code used to handle `match_path` is less scattered, and could facilitate subsequent work on #45.