### PR TITLE
Feature: add option to set default timezone

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -4,7 +4,9 @@
   "oneOf": [
     {
       "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/",
-      "enum": ["rss"]
+      "enum": [
+        "rss"
+      ]
     },
     {
       "type": "object",
@@ -45,13 +47,29 @@
               "default": null,
               "properties": {
                 "as_creation": {
-                  "type": ["boolean", "string"]
+                  "type": [
+                    "boolean",
+                    "string"
+                  ]
                 },
                 "as_update": {
-                  "type": ["boolean", "string"]
+                  "type": [
+                    "boolean",
+                    "string"
+                  ]
                 },
                 "datetime_format": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
+                },
+                "default_timezone": {
+                  "type": [
+                    "null",
+                    "string"
+                  ],
+                  "default": "UTC"
                 }
               }
             },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ plugins:
         as_creation: "date"
         as_update: false
         datetime_format: "%Y-%m-%d %H:%M"
+        default_timezone: "Europe/Paris"
       image: https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png
       match_path: ".*"
       pretty_print: false

--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -64,6 +64,7 @@ class GitRssPlugin(BasePlugin):
         # dates source
         self.src_date_created = self.src_date_updated = "git"
         self.meta_datetime_format = None
+        self.meta_default_timezone = "UTC"
         # pages storage
         self.pages_to_filter = []
         # prepare output feeds
@@ -128,6 +129,9 @@ class GitRssPlugin(BasePlugin):
             )
             self.meta_datetime_format = self.config.get("date_from_meta").get(
                 "datetime_format", "%Y-%m-%d %H:%M"
+            )
+            self.meta_default_timezone = self.config.get("date_from_meta").get(
+                "default_timezone", "UTC"
             )
             logger.debug(
                 "[rss-plugin] Dates will be retrieved from page meta (yaml "
@@ -196,6 +200,7 @@ class GitRssPlugin(BasePlugin):
             source_date_creation=self.src_date_created,
             source_date_update=self.src_date_updated,
             meta_datetime_format=self.meta_datetime_format,
+            meta_default_timezone=self.meta_default_timezone,
         )
 
         # handle custom URL parameters

--- a/mkdocs_rss_plugin/timezoner_pre39.py
+++ b/mkdocs_rss_plugin/timezoner_pre39.py
@@ -1,0 +1,44 @@
+#! python3  # noqa: E265
+
+
+"""
+    Manage timezones for pages date(time)s using zoneinfo module, added in Python 3.9.
+
+"""
+
+# ############################################################################
+# ########## Libraries #############
+# ##################################
+
+# standard library
+import logging
+from datetime import datetime
+from functools import lru_cache
+
+# ############################################################################
+# ########## Globals #############
+# ################################
+
+
+logger = logging.getLogger("mkdocs.mkdocs_rss_plugin")
+
+
+# ############################################################################
+# ########## Functions ###########
+# ################################
+
+
+@lru_cache(typed=True)
+def set_datetime_zoneinfo(
+    input_datetime: datetime, config_timezone: str = None
+) -> datetime:
+    """_summary_
+
+    :param input_datetime: _description_
+    :type input_datetime: datetime
+    :param config_timezone: _description_
+    :type config_timezone: str
+    :return: _description_
+    :rtype: datetime
+    """
+    pass

--- a/mkdocs_rss_plugin/timezoner_pre39.py
+++ b/mkdocs_rss_plugin/timezoner_pre39.py
@@ -50,4 +50,4 @@ def set_datetime_zoneinfo(
         return input_datetime.replace(tzinfo=pytz.utc)
     else:
         config_tz = pytz.timezone(config_timezone)
-        return config_tz.fromutc(input_datetime)
+        return config_tz.localize(input_datetime)

--- a/mkdocs_rss_plugin/timezoner_pre39.py
+++ b/mkdocs_rss_plugin/timezoner_pre39.py
@@ -13,7 +13,6 @@
 # standard library
 import logging
 from datetime import datetime
-from functools import lru_cache
 
 # 3rd party
 import pytz
@@ -51,4 +50,4 @@ def set_datetime_zoneinfo(
         return input_datetime.replace(tzinfo=pytz.utc)
     else:
         config_tz = pytz.timezone(config_timezone)
-        return input_datetime.replace(tzinfo=config_tz)
+        return config_tz.fromutc(input_datetime)

--- a/mkdocs_rss_plugin/timezoner_pre39.py
+++ b/mkdocs_rss_plugin/timezoner_pre39.py
@@ -2,8 +2,8 @@
 
 
 """
-    Manage timezones for pages date(time)s using zoneinfo module, added in Python 3.9.
-
+    Manage timezones for pages date(time)s using pytz module.
+    Meant to be dropped when Python 3.8 reaches EOL.
 """
 
 # ############################################################################
@@ -14,6 +14,9 @@
 import logging
 from datetime import datetime
 from functools import lru_cache
+
+# 3rd party
+import pytz
 
 # ############################################################################
 # ########## Globals #############
@@ -28,17 +31,24 @@ logger = logging.getLogger("mkdocs.mkdocs_rss_plugin")
 # ################################
 
 
-@lru_cache(typed=True)
 def set_datetime_zoneinfo(
-    input_datetime: datetime, config_timezone: str = None
+    input_datetime: datetime, config_timezone: str = "UTC"
 ) -> datetime:
-    """_summary_
+    """Apply timezone to a naive datetime.
 
-    :param input_datetime: _description_
+    :param input_datetime: offset-naive datetime
     :type input_datetime: datetime
-    :param config_timezone: _description_
-    :type config_timezone: str
-    :return: _description_
+    :param config_timezone: name of timezone as registered in IANA database,
+    defaults to "UTC". Example : Europe/Paris.
+    :type config_timezone: str, optional
+
+    :return: offset-aware datetime
     :rtype: datetime
     """
-    pass
+    if input_datetime.tzinfo:
+        return input_datetime
+    elif not config_timezone:
+        return input_datetime.replace(tzinfo=pytz.utc)
+    else:
+        config_tz = pytz.timezone(config_timezone)
+        return input_datetime.replace(tzinfo=config_tz)

--- a/mkdocs_rss_plugin/timezoner_py39.py
+++ b/mkdocs_rss_plugin/timezoner_py39.py
@@ -1,0 +1,51 @@
+#! python3  # noqa: E265
+
+
+"""
+    Manage timezones for pages date(time)s using zoneinfo module, added in Python 3.9.
+
+"""
+
+# ############################################################################
+# ########## Libraries #############
+# ##################################
+
+# standard library
+import logging
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+# ############################################################################
+# ########## Globals #############
+# ################################
+
+
+logger = logging.getLogger("mkdocs.mkdocs_rss_plugin")
+
+
+# ############################################################################
+# ########## Functions ###########
+# ################################
+
+
+def set_datetime_zoneinfo(
+    input_datetime: datetime, config_timezone: str = "UTC"
+) -> datetime:
+    """Apply timezone to a naive datetime.
+
+    :param input_datetime: offset-naive datetime
+    :type input_datetime: datetime
+    :param config_timezone: name of timezone as registered in IANA database,
+    defaults to "UTC". Example : Europe/Paris.
+    :type config_timezone: str, optional
+
+    :return: offset-aware datetime
+    :rtype: datetime
+    """
+    if input_datetime.tzinfo:
+        return input_datetime
+    elif not config_timezone:
+        return input_datetime.replace(tzinfo=timezone.utc)
+    else:
+        config_tz = ZoneInfo(config_timezone)
+        return input_datetime.replace(tzinfo=config_tz)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,3 +4,5 @@
 
 GitPython>=3.1,<3.2
 mkdocs>=1.1,<1.5
+pytz==2022.* ; python_version < "3.9"
+tzdata==2022.* ; python_version >= "3.9"

--- a/tests/fixtures/mkdocs_complete.yml
+++ b/tests/fixtures/mkdocs_complete.yml
@@ -3,17 +3,17 @@ site_name: MkDocs RSS Plugin - TEST
 site_description: Basic setup to test against MkDocs RSS plugin
 site_author: Julien Moura (Guts)
 site_url: https://guts.github.io/mkdocs-rss-plugin
-copyright: 'Guts - In Geo Veritas'
+copyright: "Guts - In Geo Veritas"
 
 # Repository
-repo_name: 'guts/mkdocs-rss-plugin'
-repo_url: 'https://github.com/guts/mkdocs-rss-plugin'
+repo_name: "guts/mkdocs-rss-plugin"
+repo_url: "https://github.com/guts/mkdocs-rss-plugin"
 
 use_directory_urls: true
 
 plugins:
   - rss:
-      abstract_chars_count: 160  # -1 for full content
+      abstract_chars_count: 160 # -1 for full content
       categories:
         - tags
       comments_path: "#__comments"
@@ -21,6 +21,7 @@ plugins:
         as_creation: "date"
         as_update: false
         datetime_format: "%Y-%m-%d %H:%M"
+        default_timezone: Europe/Paris
       enabled: true
       feed_ttl: 1440
       image: https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png

--- a/tests/test_timezoner.py
+++ b/tests/test_timezoner.py
@@ -88,11 +88,11 @@ class TestTimezoner(unittest.TestCase):
         # with timezone
         self.assertEqual(
             set_datetime_zoneinfo(test_datetime_summer_naive, "Europe/Paris"),
-            datetime.strptime("2022-07-14 14:00:00+02:00", self.fmt_datetime_aware),
+            datetime.strptime("2022-07-14 12:00:00+02:00", self.fmt_datetime_aware),
         )
         self.assertEqual(
             set_datetime_zoneinfo(test_datetime_winter_naive, "Europe/Paris"),
-            datetime.strptime("2022-12-25 23:00:00+01:00", self.fmt_datetime_aware),
+            datetime.strptime("2022-12-25 22:00:00+01:00", self.fmt_datetime_aware),
         )
 
     def test_tz_datetimes_aware(self):

--- a/tests/test_timezoner.py
+++ b/tests/test_timezoner.py
@@ -1,0 +1,133 @@
+#! python3  # noqa E265
+
+"""Usage from the repo root folder:
+
+    .. code-block:: python
+
+        # for whole test
+        python -m unittest tests.test_timezoner
+
+"""
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# Standard library
+import unittest
+from datetime import datetime
+from pathlib import Path
+
+# plugin target
+from mkdocs_rss_plugin.util import set_datetime_zoneinfo
+
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+class TestTimezoner(unittest.TestCase):
+    """Test timezone handler."""
+
+    # -- Standard methods --------------------------------------------------------
+    @classmethod
+    def setUpClass(cls):
+        """Executed when module is loaded before any test."""
+        cls.fmt_date = "%Y-%m-%d"
+        cls.fmt_datetime_aware = "%Y-%m-%d %H:%M:%S%z"
+        cls.fmt_datetime_naive = "%Y-%m-%d %H:%M"
+
+    def setUp(self):
+        """Executed before each test."""
+        pass
+
+    def tearDown(self):
+        """Executed after each test."""
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Executed after the last test."""
+        pass
+
+    # -- TESTS ---------------------------------------------------------
+    def test_tz_dates(self):
+        """Test timezone set for dates."""
+
+        test_date_summer = datetime.strptime("2022-07-14", self.fmt_date)
+        test_date_winter = datetime.strptime("2022-12-25", self.fmt_date)
+
+        self.assertEqual(
+            set_datetime_zoneinfo(test_date_summer),
+            datetime.strptime("2022-07-14 00:00:00+00:00", self.fmt_datetime_aware),
+        )
+        self.assertEqual(
+            set_datetime_zoneinfo(test_date_winter),
+            datetime.strptime("2022-12-25 00:00:00+00:00", self.fmt_datetime_aware),
+        )
+
+    def test_tz_datetimes_naive(self):
+        """Test timezone set for naive datetimes."""
+
+        test_datetime_summer_naive = datetime.strptime(
+            "2022-07-14 12:00", self.fmt_datetime_naive
+        )
+        test_datetime_winter_naive = datetime.strptime(
+            "2022-12-25 22:00", self.fmt_datetime_naive
+        )
+
+        # without timezone = UTC
+        self.assertEqual(
+            set_datetime_zoneinfo(test_datetime_summer_naive),
+            datetime.strptime("2022-07-14 12:00:00+00:00", self.fmt_datetime_aware),
+        )
+        self.assertEqual(
+            set_datetime_zoneinfo(test_datetime_winter_naive),
+            datetime.strptime("2022-12-25 22:00:00+00:00", self.fmt_datetime_aware),
+        )
+
+        # with timezone
+        self.assertEqual(
+            set_datetime_zoneinfo(test_datetime_summer_naive, "Europe/Paris"),
+            datetime.strptime("2022-07-14 12:00:00+02:00", self.fmt_datetime_aware),
+        )
+        self.assertEqual(
+            set_datetime_zoneinfo(test_datetime_winter_naive, "Europe/Paris"),
+            datetime.strptime("2022-12-25 22:00:00+01:00", self.fmt_datetime_aware),
+        )
+
+    def test_tz_datetimes_aware(self):
+        """Test timezone set for aware datetimes."""
+
+        test_datetime_summer_aware = datetime.strptime(
+            "2022-07-14 12:00:00+0400", self.fmt_datetime_aware
+        )
+        test_datetime_winter_aware = datetime.strptime(
+            "2022-12-25 22:00:00-0800", self.fmt_datetime_aware
+        )
+
+        # without timezone = UTC
+        self.assertEqual(
+            set_datetime_zoneinfo(test_datetime_summer_aware),
+            datetime.strptime("2022-07-14 12:00:00+04:00", self.fmt_datetime_aware),
+        )
+        self.assertEqual(
+            set_datetime_zoneinfo(test_datetime_winter_aware),
+            datetime.strptime("2022-12-25 22:00:00-08:00", self.fmt_datetime_aware),
+        )
+
+        # with timezone
+        self.assertEqual(
+            set_datetime_zoneinfo(test_datetime_summer_aware, "Europe/Paris"),
+            datetime.strptime("2022-07-14 12:00:00+04:00", self.fmt_datetime_aware),
+        )
+        self.assertEqual(
+            set_datetime_zoneinfo(test_datetime_winter_aware, "Europe/Paris"),
+            datetime.strptime("2022-12-25 22:00:00-08:00", self.fmt_datetime_aware),
+        )
+
+
+# ##############################################################################
+# ##### Stand alone program ########
+# ##################################
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_timezoner.py
+++ b/tests/test_timezoner.py
@@ -88,11 +88,11 @@ class TestTimezoner(unittest.TestCase):
         # with timezone
         self.assertEqual(
             set_datetime_zoneinfo(test_datetime_summer_naive, "Europe/Paris"),
-            datetime.strptime("2022-07-14 12:00:00+02:00", self.fmt_datetime_aware),
+            datetime.strptime("2022-07-14 14:00:00+02:00", self.fmt_datetime_aware),
         )
         self.assertEqual(
             set_datetime_zoneinfo(test_datetime_winter_naive, "Europe/Paris"),
-            datetime.strptime("2022-12-25 22:00:00+01:00", self.fmt_datetime_aware),
+            datetime.strptime("2022-12-25 23:00:00+01:00", self.fmt_datetime_aware),
         )
 
     def test_tz_datetimes_aware(self):


### PR DESCRIPTION
Example:

```yaml
- rss:
    date_from_meta:
      as_creation: "date"
      as_update: false
      datetime_format: "%Y-%m-%d %H:%M"
      default_timezone: "Europe/Paris"
```

Defaults to UTC.

- [x] Python >= 3.9 - no need for additional 3rd party package (or tzdata if an updated version of IANA db is needed)
- [x] Python < 3.9 - need to install pytz alongside.


Closes #133 