### PR TITLE
Improvment: more granular fallback to build timestamp

### DIFF
--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -193,6 +193,24 @@ class Util:
                 dt_created,
                 dt_updated,
             )
+        elif dt_created:
+            logger.info(
+                f"[rss-plugin] Updated date could not be retrieved for page: "
+                f"{in_page.file.abs_src_path}. Maybe it has never been committed yet?"
+            )
+            return (
+                dt_created,
+                get_build_datetime(),
+            )
+        elif dt_updated:
+            logger.info(
+                f"[rss-plugin] Creation date could not be retrieved for page: "
+                f"{in_page.file.abs_src_path}. Maybe it has never been committed yet?"
+            )
+            return (
+                get_build_datetime(),
+                dt_updated,
+            )
         else:
             logging.warning(
                 f"[rss-plugin] Dates could not be retrieved for page: {in_page.file.abs_src_path}."

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -130,7 +130,7 @@ class Util:
                 meta_datetime_timezone=meta_default_timezone,
             )
             if isinstance(dt_created, str):
-                logger.error(dt_created)
+                logger.error(f"Creation date is a string: {dt_created}")
                 dt_created = None
 
         if source_date_update != "git" and in_page.meta.get(source_date_update):
@@ -140,7 +140,7 @@ class Util:
                 meta_datetime_timezone=meta_default_timezone,
             )
             if isinstance(dt_updated, str):
-                logger.error(dt_updated)
+                logger.error(f"Update date is a string: {dt_updated}")
                 dt_updated = None
 
         # explore git log

--- a/tests/fixtures/docs/page_with_meta_no_creation_date.md
+++ b/tests/fixtures/docs/page_with_meta_no_creation_date.md
@@ -1,0 +1,16 @@
+---
+title: Page with complete meta
+authors:
+    - Guts
+    - Tim Vink
+    - liang2kl
+update: 2022-10-07 10:20
+description: First test page of mkdocs-rss-plugin test suite
+image: "https://svgsilh.com/png-512/97849.png"
+tags:
+    - test
+---
+
+# Test page with meta
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -450,7 +450,7 @@ class TestBuildRss(BaseTest):
         with tempfile.TemporaryDirectory() as tmpdirname:
             cli_result = self.build_docs_setup(
                 testproject_path="docs",
-                mkdocs_yml_filepath=Path("tests/fixtures/mkdocs_disabled.yml"),
+                mkdocs_yml_filepath=Path("tests/fixtures/mkdocs_complete.yml"),
                 output_path=tmpdirname,
                 strict=True,
             )


### PR DESCRIPTION
Until now, when a page has no creation or update date (in meta and in git log), the plugin fallbacks on build timestamp for both.

This PR makes it more granular:

- if only the creation date is missing, so it uses the build timestamp only for this one
- if only the update date is missing, so it uses the build timestamp only for this one