### PR TITLE
Set Mkdocs upper cap to major version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,6 @@
 
 
 GitPython>=3.1,<3.2
-mkdocs>=1.1,<1.5
+mkdocs>=1.1,<2
 pytz==2022.* ; python_version < "3.9"
 tzdata==2022.* ; python_version >= "3.9"


### PR DESCRIPTION
Considering the discussion in #137, let's raises the upper Mkdocs version.
For now, I set the major version to not break anything.

Later, if everything still goes well after some new Mkdocs versions released, I would remove it completely.
