### PR TITLE
Improve: handle missing site url

### DIFF
--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -172,7 +172,7 @@ class GitRssPlugin(BasePlugin):
                 base_feed.get("html_url") + OUTPUT_FEED_UPDATED
             )
         else:
-            logging.warning(
+            logger.error(
                 "[rss-plugin] The variable `site_url` is not set in the MkDocs "
                 "configuration file whereas a URL is mandatory to publish. "
                 "See: https://validator.w3.org/feed/docs/rss2.html#requiredChannelElements"

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -87,6 +87,13 @@ class Util:
         :return: complete and valid URL
         :rtype: str
         """
+        if not base_url:
+            logger.error(
+                "[rss-plugin] Base url not set, probably because 'site_url' is not set "
+                "in Mkdocs configuration file. Using an empty string instead."
+            )
+            base_url = ""
+
         # Returns a list in the structure of urlparse.ParseResult
         url_parts = list(urlparse(base_url))
         url_parts[2] += path

--- a/tests/fixtures/mkdocs_pretty_print_disabled.yml
+++ b/tests/fixtures/mkdocs_pretty_print_disabled.yml
@@ -1,6 +1,6 @@
 site_name: Test RSS Plugin
 site_description: Test RSS Plugin
-
+site_url: https://guts.github.io/mkdocs-rss-plugin
 use_directory_urls: true
 
 plugins:

--- a/tests/fixtures/mkdocs_pretty_print_enabled.yml
+++ b/tests/fixtures/mkdocs_pretty_print_enabled.yml
@@ -1,5 +1,6 @@
 site_name: Test RSS Plugin
 site_description: Test RSS Plugin
+site_url: https://guts.github.io/mkdocs-rss-plugin
 
 use_directory_urls: true
 


### PR DESCRIPTION
If `site_url` is not set in `mkdocs.yml`, the plugin was crashing the mkdocs build.

Now it log an error message when config is loaded AND every times an URL is built BUT not interrupts the build.