### PR TITLE
added delimiter-based post abstract

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -218,6 +218,7 @@ Output:
 To fill each [item description element](https://www.w3schools.com/xml/rss_tag_title_link_description_item.asp):
 
 - If this value is set to `-1`, then the articles' full HTML content will be filled into the description element.
+- When set to `0`, then content up to the post delimiter `<-- more -->` is retrieved.
 - Otherwise, the plugin first tries to retrieve the value of the keyword `description` from the [page metadata].
 - If the value is non-negative and no `description` meta is found, then the plugin retrieves the first number of characters of the page content defined by this setting. Retrieved content is the raw markdown converted rougthly into HTML.
 

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -6,6 +6,7 @@
 
 # standard library
 import logging
+import re
 import ssl
 import sys
 from datetime import date, datetime
@@ -347,7 +348,8 @@ class Util:
 
     def get_description_or_abstract(self, in_page: Page, chars_count: int = 160) -> str:
         """Returns description from page meta. If it doesn't exist, use the \
-        {chars_count} first characters from page content (in markdown).
+        {chars_count} first characters from page content (in markdown). If {chars_count} \
+        set to 0, use characters up to '<!-- more -->' delimiter.
 
         :param Page in_page: page to look at
         :param int chars_count: if page.meta.description is not set, number of chars \
@@ -361,6 +363,12 @@ class Util:
         # Set chars_count to None if it is set to be unlimited, for slicing.
         if chars_count < 0:
             chars_count = None
+        # when chars_count set to 0, return chars up to the post delimiter
+        elif chars_count == 0:
+            delim_re = r"<!--\s?more\s?-->"
+            match = re.search(delim_re, in_page.markdown)
+            if match:
+                chars_count = match.start() + 2
 
         # If the abstract chars is not unlimited and the description exists,
         # return the description.


### PR DESCRIPTION
fix #151 

Hi @Guts,
I likely took a shortcut here by using the `0` char_count value as an indicator that the chars_count should be returned up to the delimiter string, but maybe you will accept this logic.

WDYT?