### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     # run
     entry_points={"mkdocs.plugins": ["rss = mkdocs_rss_plugin.plugin:GitRssPlugin"]},
     # dependencies
-    python_requires=">=3.7, <4",
+    python_requires=">=3.8, <4",
     extras_require={
         "dev": requirements_dev,
         "doc": requirements_docs,
@@ -80,7 +80,6 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Information Technology",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
- EOL in 6 months
- build are usually run in CI where you can pick the Python version you want
- walrus operator appears in 3.8