### PR TITLE
Add option to enable/disable git use.

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -40,7 +40,6 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade -r requirements.txt
           python -m pip install --upgrade -r requirements/development.txt
-          python -m pip install --upgrade -r requirements/documentation.txt
 
       - name: Lint with flake8
         run: |

--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -53,7 +53,7 @@ jobs:
         run: python -m pip install -e .
 
       - name: Run Unit tests
-        run: pytest
+        run: python -m pytest
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -58,12 +58,11 @@ class GitRssPlugin(BasePlugin):
         ("match_path", config_options.Type(str, default=".*")),
         ("pretty_print", config_options.Type(bool, default=False)),
         ("url_parameters", config_options.Type(dict, default=None)),
+        ("use_git", config_options.Type(bool, default=True)),
     )
 
     def __init__(self):
         """Instanciation."""
-        # tooling
-        self.util = Util()
         # dates source
         self.src_date_created = self.src_date_updated = "git"
         self.meta_datetime_format = None
@@ -93,6 +92,9 @@ class GitRssPlugin(BasePlugin):
         # Skip if disabled
         if not self.config.get("enabled"):
             return config
+
+        # instanciate plugin tooling
+        self.util = Util(use_git=self.config.get("use_git", True))
 
         # check template dirs
         if not Path(DEFAULT_TEMPLATE_FILENAME).is_file():
@@ -152,10 +154,17 @@ class GitRssPlugin(BasePlugin):
                         f"format %H:%M. Trace: {err}"
                     )
 
-            logger.debug(
-                "[rss-plugin] Dates will be retrieved from page meta (yaml "
-                "frontmatter). The git log will be used as fallback."
-            )
+            if self.config.get("use_git", True):
+                logger.debug(
+                    "[rss-plugin] Dates will be retrieved FIRSTLY from page meta (yaml "
+                    "frontmatter). The git log will be used as fallback."
+                )
+            else:
+                logger.debug(
+                    "[rss-plugin] Dates will be retrieved ONLY from page meta (yaml "
+                    "frontmatter). The build date will be used as fallback, without any "
+                    "call to Git."
+                )
         else:
             logger.debug("[rss-plugin] Dates will be retrieved from git log.")
 

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -171,12 +171,17 @@ class Util:
                 meta_datetime_timezone=meta_default_timezone,
                 meta_default_time=meta_default_time,
             )
-            if isinstance(dt_created, str) or dt_created is None:
-                logger.warning(
+            if isinstance(dt_created, str):
+                logger.info(
                     f"[rss-plugin] Creation date of {in_page.file.abs_src_path} is an "
-                    f"unrecognized type: {dt_created} ({type(dt_created)})"
+                    f"a character string: {dt_created} ({type(dt_created)})"
                 )
-                dt_created = None
+
+            elif dt_created is None:
+                logger.info(
+                    f"[rss-plugin] Creation date of {in_page.file.abs_src_path} has not "
+                    "been recognized."
+                )
 
         if not self.use_git or (
             source_date_update != "git" and in_page.meta.get(source_date_update)
@@ -187,12 +192,18 @@ class Util:
                 meta_datetime_timezone=meta_default_timezone,
                 meta_default_time=meta_default_time,
             )
-            if isinstance(dt_updated, str) or dt_updated is None:
-                logger.warning(
+
+            if isinstance(dt_updated, str):
+                logger.info(
+                    f"[rss-plugin] Update date of {in_page.file.abs_src_path} is an "
+                    f"a character string: {dt_updated} ({type(dt_updated)})"
+                )
+
+            elif dt_updated is None:
+                logger.info(
                     f"[rss-plugin] Update date of {in_page.file.abs_src_path} is an "
                     f"unrecognized type: {dt_updated} ({type(dt_updated)})"
                 )
-                dt_updated = None
 
         # explore git log
         if self.git_is_valid:

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -67,21 +67,35 @@ class Util:
             try:
                 git_repo = Repo(path, search_parent_directories=True)
                 self.repo = git_repo.git
-                self.git_is_valid: bool = True
+                self.git_is_valid = True
             except InvalidGitRepositoryError as err:
-                logging.warning(
-                    f"[rss-plugin] Path '{path}' is not a valid git directory. Trace: {err}"
+                logger.warning(
+                    f"[rss-plugin] Path '{path}' is not a valid git directory. "
+                    "Only page.meta (YAML frontmatter will be used). "
+                    "To disable this warning, set 'use_git: false' in plugin options."
+                    f"Trace: {err}"
                 )
                 self.git_is_valid = False
+                use_git = False
             except Exception as err:
-                logging.warning(f"[rss-plugin] Git issue: {err}")
+                logger.warning(
+                    f"[rss-plugin] Unrecognized git issue. "
+                    "Only page.meta (YAML frontmatter will be used). "
+                    "To disable this warning, set 'use_git: false' in plugin options."
+                    f"Trace: {err}"
+                )
                 self.git_is_valid = False
+                use_git = False
 
             # Checks if user is running builds on CI and raise appropriate warnings
-            CiHandler(git_repo.git).raise_ci_warnings()
+            if self.git_is_valid:
+                CiHandler(git_repo.git).raise_ci_warnings()
         else:
             self.git_is_valid = False
-            logger.debug("[rss-plugin] Git use is disabled.")
+            logger.debug(
+                "[rss-plugin] Git use is disabled. "
+                "Only page.meta (YAML frontmatter will be used). "
+            )
 
         # save git enable/disable status
         self.use_git = use_git

--- a/tests/fixtures/mkdocs_complete_no_git.yml
+++ b/tests/fixtures/mkdocs_complete_no_git.yml
@@ -1,0 +1,43 @@
+# Project information
+site_name: MkDocs RSS Plugin - TEST
+site_description: Basic setup to test against MkDocs RSS plugin
+site_author: Julien Moura (Guts)
+site_url: https://guts.github.io/mkdocs-rss-plugin
+copyright: "Guts - In Geo Veritas"
+
+# Repository
+repo_name: "guts/mkdocs-rss-plugin"
+repo_url: "https://github.com/guts/mkdocs-rss-plugin"
+
+use_directory_urls: true
+
+plugins:
+  - rss:
+      abstract_chars_count: 160 # -1 for full content
+      categories:
+        - tags
+      comments_path: "#__comments"
+      date_from_meta:
+        as_creation: "date"
+        as_update: false
+        datetime_format: "%Y-%m-%d %H:%M"
+        default_timezone: Europe/Paris
+        default_time: "09:30"
+      enabled: true
+      feed_ttl: 1440
+      image: https://upload.wikimedia.org/wikipedia/commons/thumb/4/43/Feed-icon.svg/128px-Feed-icon.svg.png
+      length: 20
+      pretty_print: false
+      match_path: ".*"
+      url_parameters:
+        utm_source: "documentation"
+        utm_medium: "RSS"
+        utm_campaign: "feed-syndication"
+      use_git: false
+theme:
+  name: readthedocs
+  locale: fr
+
+# Extensions to enhance markdown
+markdown_extensions:
+  - meta

--- a/tests/test_build_no_git.py
+++ b/tests/test_build_no_git.py
@@ -1,0 +1,94 @@
+#! python3  # noqa E265
+
+"""Usage from the repo root folder:
+
+    .. code-block:: python
+
+        # for whole test
+        python -m unittest tests.test_build
+
+"""
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# Standard library
+import tempfile
+import unittest
+
+# logging
+from logging import DEBUG, getLogger
+from pathlib import Path
+from traceback import format_exception
+
+# test suite
+from tests.base import BaseTest
+
+logger = getLogger(__name__)
+logger.setLevel(DEBUG)
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+
+
+class TestBuildRssNoGit(BaseTest):
+    """Test MkDocs build with RSS plugin but without git."""
+
+    # -- Standard methods --------------------------------------------------------
+    @classmethod
+    def setUpClass(cls):
+        """Executed when module is loaded before any test."""
+        pass
+
+    def setUp(self):
+        """Executed before each test."""
+        pass
+
+    def tearDown(self):
+        """Executed after each test."""
+        pass
+
+    @classmethod
+    def tearDownClass(cls):
+        """Executed after the last test."""
+        # # In case of some tests failure, ensure that everything is cleaned up
+        # temp_page = Path("tests/fixtures/docs/temp_page_not_in_git_log.md")
+        # # if temp_page.exists():
+        # #     temp_page.unlink()
+
+        git_dir = Path("_git")
+        if git_dir.exists():
+            git_dir.replace(git_dir.with_name(".git"))
+
+    # -- TESTS ---------------------------------------------------------
+    def test_not_git_repo(self):
+        # temporarily rename the git folder to fake a non-git repo
+        git_dir = Path(".git")
+        git_dir_tmp = git_dir.with_name("_git")
+        git_dir.replace(git_dir_tmp)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            cli_result = self.build_docs_setup(
+                testproject_path="docs",
+                mkdocs_yml_filepath=Path("tests/fixtures/mkdocs_complete_no_git.yml"),
+                output_path=tmpdirname,
+                strict=True,
+            )
+            if cli_result.exception is not None:
+                e = cli_result.exception
+                logger.debug(format_exception(type(e), e, e.__traceback__))
+
+            self.assertEqual(cli_result.exit_code, 1)
+            self.assertIsNotNone(cli_result.exception)
+
+        # restore name
+        git_dir_tmp.replace(git_dir)
+
+
+# ##############################################################################
+# ##### Stand alone program ########
+# ##################################
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_build_no_git.py
+++ b/tests/test_build_no_git.py
@@ -5,8 +5,9 @@
     .. code-block:: python
 
         # for whole test
-        python -m unittest tests.test_build
-
+        python -m unittest tests.test_build_no_git
+        # for specific test
+        python -m unittest tests.test_build_no_git.TestBuildRssNoGit.test_not_git_repo_without_option
 """
 
 # #############################################################################
@@ -76,12 +77,37 @@ class TestBuildRssNoGit(BaseTest):
                 output_path=tmpdirname,
                 strict=True,
             )
-            if cli_result.exception is not None:
-                e = cli_result.exception
-                logger.debug(format_exception(type(e), e, e.__traceback__))
 
-            self.assertEqual(cli_result.exit_code, 1)
+            self.assertIsNone(cli_result.exception)
+            self.assertEqual(cli_result.exit_code, 0, cli_result)
+
+        # restore name
+        git_dir_tmp.replace(git_dir)
+
+    def test_not_git_repo_without_option(self):
+        # temporarily rename the git folder to fake a non-git repo
+        git_dir = Path(".git")
+        git_dir_tmp = git_dir.with_name("_git")
+        git_dir.replace(git_dir_tmp)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            cli_result = self.build_docs_setup(
+                testproject_path="docs",
+                mkdocs_yml_filepath=Path("tests/fixtures/mkdocs_complete.yml"),
+                output_path=tmpdirname,
+                strict=True,
+            )
+
             self.assertIsNotNone(cli_result.exception)
+            self.assertEqual(
+                cli_result.exit_code,
+                1,
+                format_exception(
+                    type(cli_result.exception),
+                    cli_result.exception,
+                    cli_result.exception.__traceback__,
+                ),
+            )
 
         # restore name
         git_dir_tmp.replace(git_dir)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,6 +68,7 @@ class TestConfig(BaseTest):
             "pretty_print": False,
             "match_path": ".*",
             "url_parameters": None,
+            "use_git": True,
         }
 
         # load

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -93,6 +93,7 @@ class TestConfig(BaseTest):
             "pretty_print": False,
             "match_path": ".*",
             "url_parameters": None,
+            "use_git": True,
         }
 
         # custom config


### PR DESCRIPTION
Add option `use_git`, defaults to True.

If not, the plugin does not try use the git log nor does not check if this is a valid git repository and use only informations from page meta (YAML frontmatter).

Closes #160