### PR TITLE
Fix docs for abstract_delimiter

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -257,11 +257,10 @@ Default: `150`
 
 Used to fill each [item description element](https://www.w3schools.com/xml/rss_tag_title_link_description_item.asp):
 
-- If this value is set to `-1`, then the full HTML content will be filled into the description element.
-- Otherwise, the plugin first tries to retrieve the value of the key `description` from the page metadata.
-- If the value is non-negative and no `description` meta is found, then the plugin retrieves the first number of characters of the page content defined by this setting. Retrieved content is the raw markdown converted rougthly into HTML (i.e. without extension, etc.).
+- If this value is set to `""`, then no delimiter will be used.
+- Otherwise, the plugin will retrieve content up to the delimiter.  This allows you to use a tag such as `<!-- more -->` to only include the content before that point.
 
-`abstract_delimiter`: string to mark .
+`abstract_delimiter`: string to use as stopping point.
 
 Default: `<!-- more -->`
 


### PR DESCRIPTION
The copy and paste from `abstract_chars_count` didn't match `abstract_delimiter`.

If you tried `-1`:

```
ERROR   -  Config value 'plugins': Plugin 'rss' option 'abstract_delimiter': Expected type: <class 'str'> but received: <class 'int'>
```

`""` works well.