### PR TITLE
Get right of MkDocs Theme ._vars deprecation warning

### DIFF
--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -620,13 +620,14 @@ class Util:
             return mkdocs_config.get("locale")
 
         # Some themes implement a locale or a language setting
-        if "theme" in mkdocs_config and "locale" in mkdocs_config.get("theme"):
-            locale = mkdocs_config.get("theme")._vars.get("locale")
-            return f"{locale.language}-{locale.territory}"
-        elif "theme" in mkdocs_config and "language" in mkdocs_config.get("theme"):
-            return mkdocs_config.get("theme")._vars.get("language")
-        else:
-            return None
+        if "theme" in mkdocs_config:
+            theme = mkdocs_config["theme"]
+            if "locale" in theme:
+                locale = theme["locale"]
+                return f"{locale.language}-{locale.territory}"
+            elif "language" in theme:
+                return theme["language"]
+        return None
 
     @staticmethod
     def filter_pages(pages: list, attribute: str, length: int) -> list:


### PR DESCRIPTION
As discussed in #205, I changed the code to avoid using the deprecated `Theme._vars`. 

I suspect that the case where the theme does not have a `locale` is dead code because MkDocs seems to [always set a locale](https://github.com/mkdocs/mkdocs/blob/3e0949a332ee2d4e3b0256869a9c448b03ea944d/mkdocs/theme.py#L65)? 

I did not change it because I want to tread carefully. I don't quite understand the logic in `Theme` as it seems to turn `._vars['locale']` into a `Locale` object but not `self.locale` in the case where the constructor argument for `locale` is `None`. Perhaps I am holding the wrong end of the stick here but if not then that would seem to be bug.