### PR TITLE
Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Following initiative from the author of Material for MkDocs, this plugin provide
 
 ## Development
 
-Clone the repository:
+Clone the repository. If you are not a collaborator then first [fork it
+on GitHub](https://github.com/Guts/mkdocs-rss-plugin/fork) and clone
+your fork. Change into the directory that contains the code, then:
 
 ```bash
 # install development dependencies
@@ -86,7 +88,7 @@ python -m pip install -U -r requirements/documentation.txt
 # alternatively: pip install -e .[doc]
 ```
 
-Then follow the [contribution guidelines](CONTRIBUTING.md).
+Then follow the [contribution guidelines](https://github.com/Guts/mkdocs-rss-plugin/blob/main/CONTRIBUTING.md)
 
 ## Release workflow
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,6 +34,9 @@ plugins:
         utm_campaign: "feed-syndication"
   - search
 
+watch:
+  - README.md
+
 theme:
   name: united
   language: en

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -620,13 +620,14 @@ class Util:
             return mkdocs_config.get("locale")
 
         # Some themes implement a locale or a language setting
-        if "theme" in mkdocs_config and "locale" in mkdocs_config.get("theme"):
-            locale = mkdocs_config.get("theme")._vars.get("locale")
-            return f"{locale.language}-{locale.territory}"
-        elif "theme" in mkdocs_config and "language" in mkdocs_config.get("theme"):
-            return mkdocs_config.get("theme")._vars.get("language")
-        else:
-            return None
+        if "theme" in mkdocs_config:
+            theme = mkdocs_config["theme"]
+            if "locale" in theme:
+                locale = theme["locale"]
+                return f"{locale.language}-{locale.territory}"
+            elif "language" in theme:
+                return theme["language"]
+        return None
 
     @staticmethod
     def filter_pages(pages: list, attribute: str, length: int) -> list:


### PR DESCRIPTION
A couple of small changes to the documentation. Hope they make sense.

I would suggest more if you agree that they would be useful:
- tell people to use Python's built-in `venv` to create a virtual environment
- tell them about the `PIP_REQUIRE_VIRTUALENV` variable so they don't install everything into a global environment
- add the note about configuring the `pytest --no-cov` option when debugging. I can do this for VSCode.

Edit: could look a bit like https://squidfunk.github.io/mkdocs-material/customization/#environment-setup