### PR TITLE
Feature: support material social cards plugin

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -439,5 +439,7 @@ If `false`, the integration with Social Cards is disabled.
 
 Default: `true`.
 
+> See [the related section in integrations page](./integrations.md#social-cards-plugin-from-material-theme).
+
 <!-- Hyperlinks reference -->
 [page metadata]: https://python-markdown.github.io/extensions/meta_data/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -133,7 +133,7 @@ Output:
 
 For a sample see [homepage](./index.md#quickstart).
 
-### Disabling the plugin
+### `enabled`: enabling/disabling the plugin
 
 You can use the `enabled` option to optionally disable this plugin. A possible use case is local development where you might want faster build times. It's recommended to use this option with an environment variable together with a default fallback (introduced in `mkdocs` v1.2.1, see [docs](https://www.mkdocs.org/user-guide/configuration/#environment-variables)). Example:
 
@@ -150,7 +150,7 @@ export MKDOCS_ENABLE_RSS_PLUGIN=false
 mkdocs serve
 ```
 
-### Channel image
+### `image`: set the channel image
 
 `image`: URL to image to use as feed illustration.
 
@@ -176,7 +176,7 @@ Output:
 </image>
 ```
 
-### Item comments path
+### `comments_path`: item comments path
 
 `comments_path`: path to add to each item URL pointing.
 
@@ -194,13 +194,13 @@ For example, if you're using Material for Mkdocs with comment integration (Disqu
 </item>
 ```
 
-### Feed length
+### `length`: number of items to include in feed
 
 `length`: number of pages to include as feed items (entries).
 
 Default: `20`
 
-### Feed TTL
+### `feed_ttl`: feed's cache time
 
 `feed_ttl`: number of minutes to be cached. Inserted as channel `ttl` element. See: [W3C RSS 2.0 documentation](https://www.w3schools.com/xml/rss_tag_ttl.asp).
 
@@ -212,7 +212,7 @@ Output:
 <ttl>1440</ttl>
 ```
 
-### Item description length
+### `abstract_chars_count`: item description length
 
 To fill each [item description element](https://www.w3schools.com/xml/rss_tag_title_link_description_item.asp):
 
@@ -227,7 +227,7 @@ Default: `150`
 
 ----
 
-#### Abstract delimiter
+#### `abstract_delimiter`: abstract delimiter
 
 Used to fill each [item description element](https://www.w3schools.com/xml/rss_tag_title_link_description_item.asp):
 
@@ -241,7 +241,7 @@ Default: `<!-- more -->`
 
 ----
 
-### Item categories
+### `categories`: item categories
 
 `categories`: list of page metadata values to use as [RSS item categories](https://www.w3schools.com/xml/rss_tag_category_item.asp).
 
@@ -303,7 +303,7 @@ Output:
 
 ----
 
-### Dates overriding
+### `date_from_meta`: override dates from git log with page.meta
 
 Basically, the plugin aims to retrieve creation and update dates from git log. But sometimes, it does not match the content workflow: markdown generated from sources, .
 
@@ -361,7 +361,7 @@ At the end, into the RSS you will get:
         - for Python >= 3.9, it uses the standard library and ships [tzdata](https://pypi.org/project/tzdata/) only on Windows which do not provide such data
         - for Python < 3.9, [pytz](https://pypi.org/project/pytz/) is shipped.
 
-### Prettified output
+### `pretty_print`: prettified XML
 
 By default, the output file is minified, using Jinja2 strip options and manual work. It's possible to disable it and prettify the output using `pretty_print: true`.
 
@@ -373,7 +373,7 @@ plugins:
 
 Default: `False`.
 
-### Filter pages
+### `match_path`: filter pages to include in feed
 
 This adds a `match_path` option which should be a regex pattern matching the path to your files within the `docs_dir`. For example if you had a blog under `docs/blog` where `docs_dir` is `docs` you might use:
 
@@ -393,7 +393,7 @@ plugins:
 
 Default: `.*`.
 
-### URL parameters
+### `url_parameters`: additional URL parameters
 
 This option allows you to add parameters to the URLs of the RSS feed items. It works as a dictionary of keys/values that is passed to [Python *urllib.parse.urlencode*](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlencode).  
 One possible use case is the addition of [Urchin Tracking Module (UTM) parameters](https://en.wikipedia.org/wiki/UTM_parameters):
@@ -424,6 +424,14 @@ Will result in:
 ```
 
 Default: `None`.
+
+### `use_git`: enable/disable git log
+
+If `false`, the plugin does not try use the git log nor does not check if this is a valid git repository and use informations exclusively from `page.meta` (YAML frontmatter).
+
+Useful if you build your documentation in an environment where you can't easily install git.
+
+Default: `true`.
 
 <!-- Hyperlinks reference -->
 [page metadata]: https://python-markdown.github.io/extensions/meta_data/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -433,5 +433,11 @@ Useful if you build your documentation in an environment where you can't easily 
 
 Default: `true`.
 
+### `use_material_social_cards`: enable/disable integration with Material Social Cards plugin
+
+If `false`, the integration with Social Cards is disabled.
+
+Default: `true`.
+
 <!-- Hyperlinks reference -->
 [page metadata]: https://python-markdown.github.io/extensions/meta_data/

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 authors:
-  - "Julien Moura"
+  - dev@ingeoveritas.com (Julien Moura)
 date: 2020-12-31 14:20
 description: Configuration steps and settings for MkDocs RSS plugin
 icon: material/book-cog

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ authors:
   - vinktim@gmail.com (Tim Vink)
 date: 2020-07-06
 description: "MkDocs RSS plugin: generate RSS feeds for your static website using git log ad YAML frontmatter (markdown pages'metadata header)."
-image: "rss_icon.svg"
+image: "assets/rss_icon.svg"
 tags:
   - Mkdocs
   - plugin

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,7 @@ Or it could be displayed as a Feedly follow button:
 
 - Plugin logic is inspired from [Tim Vink git-based plugins](https://github.com/timvink?tab=repositories&q=mkdocs-git&type=&language=) and main parts of Git stuff are nearly copied/pasted.
 - Using magic mainly from:
-  - [GitPython](https://gitpython.readthedocs.io/)
-  - [Jinja2](https://jinja.palletsprojects.com/)
+    - [GitPython](https://gitpython.readthedocs.io/)
+    - [Jinja2](https://jinja.palletsprojects.com/)
 - Documentation colors are a tribute to the classic RSS color scheme: orange and white.
 - Logo generated with DALL·E.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 ---
 title: The MkDocs RSS Plugin
 authors:
-  - Julien Moura <dev@ingeoveritas.com>
-  - Tim Vink <vinktim@gmail.com>
+  - dev@ingeoveritas.com (Julien Moura)
+  - vinktim@gmail.com (Tim Vink)
 date: 2020-07-06
 description: "MkDocs RSS plugin: generate RSS feeds for your static website using git log ad YAML frontmatter (markdown pages'metadata header)."
 image: "rss_icon.svg"

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -3,6 +3,22 @@ title: Integrations
 icon: octicons/plug-16
 ---
 
+## Social Cards plugin (from Material theme)
+
+Since version 1.10, the plugin integrates with the [Social Cards plugin (shipped with Material theme)](https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/) (see also [the full plugin documentation here](https://squidfunk.github.io/mkdocs-material/plugins/social/)).
+
+Here's how the RSS plugin prioritizes the image to be used in the feed:
+
+1. an image (local path or URL) is defined in the page's YAML header of the page with the key `image`. Typically: `image: path_or_url_to_image.webp`.
+1. an image (local path or URL) is defined in the page's YAML header with the key `illustration`. Typically: `illustration: path_or_url_to_image.webp`.
+1. if neither is defined, but both the social plugin and the cards option are enabled, then the social card image is used.
+
+If you don't want this integration, you can disable it with the option: `use_material_social_cards=false`.
+
+> See [related section in settings](./configuration.md#use_material_social_cards-enabledisable-integration-with-material-social-cards-plugin).
+
+----
+
 ## Reference RSS feeds in HTML meta-tags
 
 To facilitate the discovery of RSS feeds, it's recommended to add relevant meta-tags in `<head>` section in HTML pages.

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -127,6 +127,13 @@
               "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#url-parameters",
               "type": "object",
               "default": null
+            },
+            "use_git": {
+              "title": "Enable/Disable git use.",
+              "description": "Disable it if you want to use only page.meta values.",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#disabling-the-plugin",
+              "type": "boolean",
+              "default": true
             }
           },
           "additionalProperties": false

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -134,6 +134,12 @@
               "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#use_git-enabledisable-git-log",
               "type": "boolean",
               "default": true
+            },
+            "use_material_social_cards": {
+              "title": "Enable/Disable integration with Social Cards plugin from Material theme.",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#disabling-the-plugin",
+              "type": "boolean",
+              "default": true
             }
           },
           "additionalProperties": false

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -17,14 +17,14 @@
           "properties": {
             "abstract_chars_count": {
               "title": "Number of characters to use as item description if it's not present within the page metadata. If this value is set to -1, then the articles' full HTML content will be filled into the description element.",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#feed-length",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#abstract_chars_count-item-description-length",
               "type": "integer",
               "default": 160,
               "minimum": -1
             },
             "categories": {
               "title": "List of page metadata keys to use as item categories.",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#item-categories",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#categories-item-categories",
               "type": "array",
               "default": null,
               "items": {
@@ -35,14 +35,14 @@
             },
             "comments_path": {
               "title": "Part of URL to the items' comment div.",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#item-comments-path",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#comments_path-item-comments-path",
               "type": "string",
               "default": null,
               "format": "uri-reference"
             },
             "date_from_meta": {
               "title": "Use date from page metadata instead of git log.",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#dates-overriding",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#date_from_meta-override-dates-from-git-log-with-pagemeta",
               "type": "object",
               "default": null,
               "properties": {
@@ -88,50 +88,50 @@
             },
             "enabled": {
               "title": "Enable/Disable plugin",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#disabling-the-plugin",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#enabled-enablingdisabling-the-plugin",
               "type": "boolean",
               "default": true
             },
             "feed_ttl": {
               "title": "Number of pages to include as feed items (entries).",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#feed-length",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#feed_ttl-feeds-cache-time",
               "type": "integer",
               "default": 1440
             },
             "image": {
               "title": "Feed channel illustration",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#channel-image",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#image-set-the-channel-image",
               "type": "string",
               "default": null
             },
             "length": {
               "title": "Number of pages to include as feed items (entries).",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#feed-length",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#length-number-of-items-to-include-in-feed",
               "type": "integer",
               "default": 20
             },
             "match_path": {
               "title": "Regex match pattern to filter pages.",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#filter-pages",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#match_path-filter-pages-to-include-in-feed",
               "type": "string",
               "default": ".*"
             },
             "pretty_print": {
               "title": "Minify/Prettify output",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#prettified-output",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#pretty_print-prettified-xml",
               "type": "boolean",
               "default": false
             },
             "url_parameters": {
               "title": "URL parameters to include in the item URL.",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#url-parameters",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#url_parameters-additional-url-parameters",
               "type": "object",
               "default": null
             },
             "use_git": {
               "title": "Enable/Disable git use.",
               "description": "Disable it if you want to use only page.meta values.",
-              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#disabling-the-plugin",
+              "markdownDescription": "https://guts.github.io/mkdocs-rss-plugin/configuration/#use_git-enabledisable-git-log",
               "type": "boolean",
               "default": true
             }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,9 @@ markdown_extensions:
           case: lower
   - toc:
       permalink: "#"
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
 
 nav:
   - Home: index.md
@@ -103,7 +106,6 @@ plugins:
       enabled: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL, true]
       cache_dir: !ENV [MKDOCS_PLUGIN_SOCIAL_CACHE_DIR, .cache/plugins/social]
   - termynal:
-      title: "Youpi"
       prompt_literal_start:
         - "$"
         - ">"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -100,11 +100,14 @@ plugins:
         utm_source: "documentation"
         utm_medium: "RSS"
         utm_campaign: "feed-syndication"
+      use_git: true
+      use_material_social_cards: true
   - search:
       lang: en
   - social:
       enabled: !ENV [MKDOCS_ENABLE_PLUGIN_SOCIAL, true]
       cache_dir: !ENV [MKDOCS_PLUGIN_SOCIAL_CACHE_DIR, .cache/plugins/social]
+      cards: true
   - termynal:
       prompt_literal_start:
         - "$"

--- a/mkdocs_rss_plugin/config.py
+++ b/mkdocs_rss_plugin/config.py
@@ -31,3 +31,4 @@ class RssPluginConfig(Config):
     pretty_print = config_options.Type(bool, default=False)
     url_parameters = config_options.Optional(config_options.Type(dict))
     use_git = config_options.Type(bool, default=True)
+    use_material_social_cards = config_options.Type(bool, default=True)

--- a/mkdocs_rss_plugin/integrations/theme_material_social_plugin.py
+++ b/mkdocs_rss_plugin/integrations/theme_material_social_plugin.py
@@ -7,6 +7,7 @@
 # standard library
 import logging
 from pathlib import Path
+from typing import Optional
 
 # 3rd party
 from mkdocs.config.config_options import Config
@@ -174,13 +175,13 @@ class IntegrationMaterialSocialCards:
         return social_plugin_cfg.config.cards_dir
 
     def get_social_card_build_path_for_page(
-        self, mkdocs_page: Page, mkdocs_site_dir: str | None = None
+        self, mkdocs_page: Page, mkdocs_site_dir: Optional[str] = None
     ) -> Path:
         """Get social card URL for a specific page in documentation.
 
         Args:
             mkdocs_page (Page): Mkdocs page object.
-            mkdocs_site_dir (str | None, optional): Mkdocs build site dir. If None, the
+            mkdocs_site_dir (Optional[str], optional): Mkdocs build site dir. If None, the
                 'class.mkdocs_site_build_dir' is used. is Defaults to None.
 
         Returns:
@@ -197,13 +198,13 @@ class IntegrationMaterialSocialCards:
     def get_social_card_url_for_page(
         self,
         mkdocs_page: Page,
-        mkdocs_site_url: str | None = None,
+        mkdocs_site_url: Optional[str] = None,
     ) -> str:
         """Get social card URL for a specific page in documentation.
 
         Args:
             mkdocs_page (Page): Mkdocs page object.
-            mkdocs_site_url (str | None, optional): Mkdocs site URL. If None, the
+            mkdocs_site_url (Optional[str], optional): Mkdocs site URL. If None, the
                 'class.mkdocs_site_url' is used. is Defaults to None.
 
         Returns:

--- a/mkdocs_rss_plugin/integrations/theme_material_social_plugin.py
+++ b/mkdocs_rss_plugin/integrations/theme_material_social_plugin.py
@@ -1,0 +1,100 @@
+#! python3  # noqa: E265
+
+# ############################################################################
+# ########## Libraries #############
+# ##################################
+
+# standard library
+import logging
+
+# 3rd party
+from mkdocs.config.config_options import Config
+from mkdocs.structure.pages import Page
+
+# ############################################################################
+# ########## Globals #############
+# ################################
+
+logger = logging.getLogger("mkdocs.mkdocs_rss_plugin")
+
+# ############################################################################
+# ########## Logic ###############
+# ################################
+
+
+def is_theme_material(mkdocs_config: Config) -> bool:
+    """Check if the theme set in mkdocs.yml is material or not.
+
+    Args:
+        mkdocs_config (Config): Mkdocs website configuration object.
+
+    Returns:
+        bool: True if the theme's name is 'material'. False if not.
+    """
+    return mkdocs_config.theme.name == "material"
+
+
+def is_social_plugin_enabled_mkdocs(mkdocs_config: Config) -> bool:
+    """Check if social cards plugin is enabled.
+
+    Args:
+        mkdocs_config (Config): Mkdocs website configuration object.
+
+    Returns:
+        bool: True if the theme material and the plugin social cards is enabled.
+    """
+    if not is_theme_material(mkdocs_config=mkdocs_config):
+        logger.debug(
+            "[rss-plugin] Installed theme is not 'material'. Integration disabled."
+        )
+        return False
+
+    if not mkdocs_config.plugins.get("material/social"):
+        logger.debug("[rss-plugin] Social plugin not listed in configuration.")
+        return False
+
+    social_plugin_cfg = mkdocs_config.plugins.get("material/social")
+
+    if not social_plugin_cfg.config.enabled or not social_plugin_cfg.config.cards:
+        logger.debug(
+            "[rss-plugin] Social plugin is installed, present but cards are disabled."
+        )
+        return False
+
+    logger.debug("[rss-plugin] Social cards are enabled in Mkdocs configuration.")
+    return True
+
+
+def is_social_plugin_enabled_page(mkdocs_page: Page) -> bool:
+    """Check if the social plugin is enabled or disabled for a specific page. Plugin
+        has to enabled in Mkdocs configuration before.
+
+    Args:
+        mkdocs_page (Page): Mkdocs page object.
+
+    Returns:
+        bool: True if the social cards are enabled for a page.
+    """
+    if (
+        "social" in mkdocs_page.meta
+        and mkdocs_page.meta.get("social").get(
+            "cards", is_social_plugin_enabled_mkdocs()
+        )
+        is True
+    ):
+        return True
+
+    return False
+
+
+def get_social_card_url_for_page(mkdocs_config: Config, mkdocs_page: Page) -> str:
+    """Get social card URL for a specific page in documentation.
+
+    Args:
+        mkdocs_config (Config): Mkdocs website configuration object.
+        mkdocs_page (Page): Mkdocs page object.
+
+    Returns:
+        str: URL to the image once published
+    """
+    return f"{mkdocs_config.site_url}assets/images/social{mkdocs_page.abs_url[:-1]}.png"

--- a/mkdocs_rss_plugin/integrations/theme_material_social_plugin.py
+++ b/mkdocs_rss_plugin/integrations/theme_material_social_plugin.py
@@ -6,6 +6,7 @@
 
 # standard library
 import logging
+from pathlib import Path
 
 # 3rd party
 from mkdocs.config.config_options import Config
@@ -22,79 +23,193 @@ logger = logging.getLogger("mkdocs.mkdocs_rss_plugin")
 # ################################
 
 
-def is_theme_material(mkdocs_config: Config) -> bool:
-    """Check if the theme set in mkdocs.yml is material or not.
+class IntegrationMaterialSocialCards:
+    # attributes
+    IS_ENABLED: bool = True
+    IS_SOCIAL_PLUGIN_ENABLED: bool = True
+    IS_SOCIAL_PLUGIN_CARDS_ENABLED: bool = True
+    IS_THEME_MATERIAL: bool = False
 
-    Args:
-        mkdocs_config (Config): Mkdocs website configuration object.
+    def __init__(self, mkdocs_config: Config, switch_force: bool = True) -> None:
+        """Integration instanciation.
 
-    Returns:
-        bool: True if the theme's name is 'material'. False if not.
-    """
-    return mkdocs_config.theme.name == "material"
-
-
-def is_social_plugin_enabled_mkdocs(mkdocs_config: Config) -> bool:
-    """Check if social cards plugin is enabled.
-
-    Args:
-        mkdocs_config (Config): Mkdocs website configuration object.
-
-    Returns:
-        bool: True if the theme material and the plugin social cards is enabled.
-    """
-    if not is_theme_material(mkdocs_config=mkdocs_config):
-        logger.debug(
-            "[rss-plugin] Installed theme is not 'material'. Integration disabled."
+        Args:
+            mkdocs_config (Config): Mkdocs website configuration object.
+            switch_force (bool, optional): option to force integration disabling. Set
+                it to False to disable it even if Social Cards are enabled in Mkdocs
+                configuration. Defaults to True.
+        """
+        # check if the integration can be enabled or not
+        self.IS_SOCIAL_PLUGIN_CARDS_ENABLED = (
+            self.is_social_plugin_and_cards_enabled_mkdocs(mkdocs_config=mkdocs_config)
         )
-        return False
 
-    if not mkdocs_config.plugins.get("material/social"):
-        logger.debug("[rss-plugin] Social plugin not listed in configuration.")
-        return False
-
-    social_plugin_cfg = mkdocs_config.plugins.get("material/social")
-
-    if not social_plugin_cfg.config.enabled or not social_plugin_cfg.config.cards:
-        logger.debug(
-            "[rss-plugin] Social plugin is installed, present but cards are disabled."
+        # if every conditions are True, enable the integration
+        self.IS_ENABLED = all(
+            [
+                self.IS_THEME_MATERIAL,
+                self.IS_SOCIAL_PLUGIN_ENABLED,
+                self.IS_SOCIAL_PLUGIN_CARDS_ENABLED,
+            ]
         )
-        return False
 
-    logger.debug("[rss-plugin] Social cards are enabled in Mkdocs configuration.")
-    return True
+        # except if the end-user wants to disable it
+        if switch_force is False:
+            self.IS_ENABLED = False
+            logger.debug(
+                "[rss-plugin] Integration with Social Cards (Material theme) is "
+                "disabled in plugin's option in Mkdocs configuration."
+            )
 
+        # if enabled, save some config elements
+        if self.IS_ENABLED:
+            self.mkdocs_site_url = mkdocs_config.site_url
+            self.mkdocs_site_build_dir = mkdocs_config.site_dir
+            self.social_cards_assets_dir = self.get_social_cards_dir(
+                mkdocs_config=mkdocs_config
+            )
 
-def is_social_plugin_enabled_page(mkdocs_page: Page) -> bool:
-    """Check if the social plugin is enabled or disabled for a specific page. Plugin
-        has to enabled in Mkdocs configuration before.
+    def is_theme_material(self, mkdocs_config: Config) -> bool:
+        """Check if the theme set in mkdocs.yml is material or not.
 
-    Args:
-        mkdocs_page (Page): Mkdocs page object.
+        Args:
+            mkdocs_config (Config): Mkdocs website configuration object.
 
-    Returns:
-        bool: True if the social cards are enabled for a page.
-    """
-    if (
-        "social" in mkdocs_page.meta
-        and mkdocs_page.meta.get("social").get(
-            "cards", is_social_plugin_enabled_mkdocs()
-        )
-        is True
-    ):
+        Returns:
+            bool: True if the theme's name is 'material'. False if not.
+        """
+        self.IS_THEME_MATERIAL = mkdocs_config.theme.name == "material"
+        return self.IS_THEME_MATERIAL
+
+    def is_social_plugin_enabled_mkdocs(self, mkdocs_config: Config) -> bool:
+        """Check if social plugin is installed and enabled.
+
+        Args:
+            mkdocs_config (Config): Mkdocs website configuration object.
+
+        Returns:
+            bool: True if the theme material and the plugin social cards is enabled.
+        """
+        if not self.is_theme_material(mkdocs_config=mkdocs_config):
+            logger.debug(
+                "[rss-plugin] Installed theme is not 'material'. Integration disabled."
+            )
+            return False
+
+        if not mkdocs_config.plugins.get("material/social"):
+            logger.debug("[rss-plugin] Social plugin not listed in configuration.")
+            return False
+
+        social_plugin_cfg = mkdocs_config.plugins.get("material/social")
+
+        if not social_plugin_cfg.config.enabled:
+            logger.debug("[rss-plugin] Social plugin is installed but disabled.")
+            self.IS_SOCIAL_PLUGIN_ENABLED = False
+            return False
+
+        logger.debug("[rss-plugin] Social plugin is enabled in Mkdocs configuration.")
+        self.IS_SOCIAL_PLUGIN_CARDS_ENABLED = True
         return True
 
-    return False
+    def is_social_plugin_and_cards_enabled_mkdocs(self, mkdocs_config: Config) -> bool:
+        """Check if social cards plugin is enabled.
 
+        Args:
+            mkdocs_config (Config): Mkdocs website configuration object.
 
-def get_social_card_url_for_page(mkdocs_config: Config, mkdocs_page: Page) -> str:
-    """Get social card URL for a specific page in documentation.
+        Returns:
+            bool: True if the theme material and the plugin social cards is enabled.
+        """
+        if not self.is_social_plugin_enabled_mkdocs(mkdocs_config=mkdocs_config):
+            return False
 
-    Args:
-        mkdocs_config (Config): Mkdocs website configuration object.
-        mkdocs_page (Page): Mkdocs page object.
+        social_plugin_cfg = mkdocs_config.plugins.get("material/social")
 
-    Returns:
-        str: URL to the image once published
-    """
-    return f"{mkdocs_config.site_url}assets/images/social{mkdocs_page.abs_url[:-1]}.png"
+        if not social_plugin_cfg.config.cards:
+            logger.debug(
+                "[rss-plugin] Social plugin is installed, present but cards are disabled."
+            )
+            self.IS_SOCIAL_PLUGIN_CARDS_ENABLED = False
+            return False
+
+        logger.debug("[rss-plugin] Social cards are enabled in Mkdocs configuration.")
+        self.IS_SOCIAL_PLUGIN_CARDS_ENABLED = True
+        return True
+
+    def is_social_plugin_enabled_page(
+        self, mkdocs_page: Page, fallback_value: bool = True
+    ) -> bool:
+        """Check if the social plugin is enabled or disabled for a specific page. Plugin
+            has to enabled in Mkdocs configuration before.
+
+        Args:
+            mkdocs_page (Page): Mkdocs page object.
+            fallback_value (bool, optional): fallback value. It might be the
+                'plugins.social.cards.enabled' option in Mkdocs config. Defaults to True.
+
+        Returns:
+            bool: True if the social cards are enabled for a page.
+        """
+        return mkdocs_page.meta.get("social", {"cards": fallback_value}).get(
+            "cards", fallback_value
+        )
+
+    def get_social_cards_dir(self, mkdocs_config: Config) -> str:
+        """Get Social Cards folder within Mkdocs site_dir.
+        See: https://squidfunk.github.io/mkdocs-material/plugins/social/#config.cards_dir
+
+        Args:
+            mkdocs_config (Config): Mkdocs website configuration object.
+
+        Returns:
+            str: True if the theme material and the plugin social cards is enabled.
+        """
+        social_plugin_cfg = mkdocs_config.plugins.get("material/social")
+
+        logger.debug(
+            "[rss-plugin] Social cards folder in Mkdocs build directory: "
+            f"{social_plugin_cfg.config.cards_dir}."
+        )
+
+        return social_plugin_cfg.config.cards_dir
+
+    def get_social_card_build_path_for_page(
+        self, mkdocs_page: Page, mkdocs_site_dir: str | None = None
+    ) -> Path:
+        """Get social card URL for a specific page in documentation.
+
+        Args:
+            mkdocs_page (Page): Mkdocs page object.
+            mkdocs_site_dir (str | None, optional): Mkdocs build site dir. If None, the
+                'class.mkdocs_site_build_dir' is used. is Defaults to None.
+
+        Returns:
+            str: URL to the image once published
+        """
+        if mkdocs_site_dir is None and self.mkdocs_site_build_dir:
+            mkdocs_site_dir = self.mkdocs_site_build_dir
+
+        return Path(
+            f"{mkdocs_site_dir}/{self.social_cards_assets_dir}/"
+            f"{Path(mkdocs_page.file.src_uri).with_suffix('.png')}"
+        )
+
+    def get_social_card_url_for_page(
+        self,
+        mkdocs_page: Page,
+        mkdocs_site_url: str | None = None,
+    ) -> str:
+        """Get social card URL for a specific page in documentation.
+
+        Args:
+            mkdocs_page (Page): Mkdocs page object.
+            mkdocs_site_url (str | None, optional): Mkdocs site URL. If None, the
+                'class.mkdocs_site_url' is used. is Defaults to None.
+
+        Returns:
+            str: URL to the image once published
+        """
+        if mkdocs_site_url is None and self.mkdocs_site_url:
+            mkdocs_site_url = self.mkdocs_site_url
+
+        return f"{mkdocs_site_url}assets/images/social/{Path(mkdocs_page.file.src_uri).with_suffix('.png')}"

--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -17,7 +17,7 @@ from typing import Optional
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from mkdocs.config import config_options
 from mkdocs.exceptions import PluginError
-from mkdocs.plugins import BasePlugin
+from mkdocs.plugins import BasePlugin, event_priority
 from mkdocs.structure.pages import Page
 from mkdocs.utils import get_build_timestamp
 
@@ -186,6 +186,7 @@ class GitRssPlugin(BasePlugin[RssPluginConfig]):
         # ending event
         return config
 
+    @event_priority(priority=-75)
     def on_page_content(
         self, html: str, page: Page, config: config_options.Config, files
     ) -> str:

--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -30,6 +30,9 @@ from mkdocs_rss_plugin.constants import (
     OUTPUT_FEED_CREATED,
     OUTPUT_FEED_UPDATED,
 )
+from mkdocs_rss_plugin.integrations.theme_material_social_plugin import (
+    is_social_plugin_enabled_mkdocs,
+)
 from mkdocs_rss_plugin.models import PageInformation
 from mkdocs_rss_plugin.util import Util
 
@@ -79,8 +82,16 @@ class GitRssPlugin(BasePlugin[RssPluginConfig]):
         if not self.config.enabled:
             return config
 
+        # integrations - check if theme is Material and if social cards are enabled
+        self.integration_material_social_cards_enabled = (
+            is_social_plugin_enabled_mkdocs(mkdocs_config=config)
+        )
+
         # instanciate plugin tooling
-        self.util = Util(use_git=self.config.use_git)
+        self.util = Util(
+            use_git=self.config.use_git,
+            integration_material=self.integration_material_social_cards_enabled,
+        )
 
         # check template dirs
         if not Path(DEFAULT_TEMPLATE_FILENAME).is_file():

--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -31,7 +31,7 @@ from mkdocs_rss_plugin.constants import (
     OUTPUT_FEED_UPDATED,
 )
 from mkdocs_rss_plugin.integrations.theme_material_social_plugin import (
-    is_social_plugin_enabled_mkdocs,
+    IntegrationMaterialSocialCards,
 )
 from mkdocs_rss_plugin.models import PageInformation
 from mkdocs_rss_plugin.util import Util
@@ -83,21 +83,15 @@ class GitRssPlugin(BasePlugin[RssPluginConfig]):
             return config
 
         # integrations - check if theme is Material and if social cards are enabled
-        if self.config.use_material_social_cards:
-            self.integration_material_social_cards_enabled = (
-                is_social_plugin_enabled_mkdocs(mkdocs_config=config)
-            )
-        else:
-            logger.debug(
-                "[rss-plugin] Integration with Social Cards (Material theme) is "
-                "disabled by option in Mkdocs configuration."
-            )
-            self.integration_material_social_cards_enabled = False
+        self.integration_material_social_cards = IntegrationMaterialSocialCards(
+            mkdocs_config=config,
+            switch_force=self.config.use_material_social_cards,
+        )
 
         # instanciate plugin tooling
         self.util = Util(
             use_git=self.config.use_git,
-            integration_material_social_cards=self.integration_material_social_cards_enabled,
+            integration_material_social_cards=self.integration_material_social_cards,
         )
 
         # check template dirs

--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -83,14 +83,21 @@ class GitRssPlugin(BasePlugin[RssPluginConfig]):
             return config
 
         # integrations - check if theme is Material and if social cards are enabled
-        self.integration_material_social_cards_enabled = (
-            is_social_plugin_enabled_mkdocs(mkdocs_config=config)
-        )
+        if self.config.use_material_social_cards:
+            self.integration_material_social_cards_enabled = (
+                is_social_plugin_enabled_mkdocs(mkdocs_config=config)
+            )
+        else:
+            logger.debug(
+                "[rss-plugin] Integration with Social Cards (Material theme) is "
+                "disabled by option in Mkdocs configuration."
+            )
+            self.integration_material_social_cards_enabled = False
 
         # instanciate plugin tooling
         self.util = Util(
             use_git=self.config.use_git,
-            integration_material=self.integration_material_social_cards_enabled,
+            integration_material_social_cards=self.integration_material_social_cards_enabled,
         )
 
         # check template dirs

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -27,6 +27,9 @@ from mkdocs.utils import get_build_datetime
 # package
 from mkdocs_rss_plugin.constants import REMOTE_REQUEST_HEADERS
 from mkdocs_rss_plugin.git_manager.ci import CiHandler
+from mkdocs_rss_plugin.integrations.theme_material_social_plugin import (
+    is_theme_material,
+)
 
 # conditional imports
 if sys.version_info < (3, 9):
@@ -51,11 +54,19 @@ class Util:
 
     git_is_valid: bool = False
 
-    def __init__(self, path: str = ".", use_git: bool = True):
+    def __init__(
+        self,
+        path: str = ".",
+        use_git: bool = True,
+        integration_material_social_cards: bool = False,
+    ):
         """Class hosting the plugin logic.
 
-        :param str path: path tot the git repository to use. Defaults to: "." - optional
-        :param bool use_git: flag to use git under the hood or not, defaults to True
+        Args:
+            path (str, optional): path to the git repository to use. Defaults to ".".
+            use_git (bool, optional): flag to use git under the hood or not. Defaults to True.
+            integration_material_social_cards (bool, optional): option to enable
+                integration with Social Cards plugin from Material theme. Defaults to False.
         """
         if use_git:
             logger.debug("[rss-plugin] Git use is disabled.")
@@ -94,6 +105,9 @@ class Util:
 
         # save git enable/disable status
         self.use_git = use_git
+
+        # save integrations
+        self.integration_material_social_cards = integration_material_social_cards
 
     def build_url(self, base_url: str, path: str, args_dict: dict = None) -> str:
         """Build URL using base URL, cumulating existing and passed path, \
@@ -624,7 +638,7 @@ class Util:
         # Some themes implement a locale or a language settings
         if "theme" in mkdocs_config:
             if (
-                mkdocs_config.theme.name == "material"
+                is_theme_material(mkdocs_config=mkdocs_config)
                 and "language" in mkdocs_config.theme
             ):
                 # TODO: remove custom behavior when Material theme switches to locale

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -480,7 +480,7 @@ class Util:
         else:
             return description if description else ""
 
-    def get_image(self, in_page: Page, base_url: str) -> Optional[tuple[str, str, int]]:
+    def get_image(self, in_page: Page, base_url: str) -> Optional[Tuple[str, str, int]]:
         """Get page's image from page meta or social cards and returns properties.
 
         Args:
@@ -489,7 +489,7 @@ class Util:
                 with local path.
 
         Returns:
-            Optional[tuple[str, str, int]]: (image url, mime type, image length) or None if
+            Optional[Tuple[str, str, int]]: (image url, mime type, image length) or None if
                 there is no image set
         """
         if in_page.meta.get("image"):

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -521,10 +521,19 @@ class Util:
                 f"{in_page.file.src_uri}. Using local image to get mime and length: "
                 f"{img_local_path}"
             )
+
+            if img_local_path.is_file():
+                img_length = img_local_path.stat().st_size
+            else:
+                logger.debug(
+                    f"[rss-plugin] Social card: {img_local_path} still not exists."
+                )
+                img_length = None
+
             return (
                 img_url,
                 guess_type(url=img_local_path, strict=False)[0],
-                img_local_path.stat().st_size,
+                img_length,
             )
 
         else:

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -12,7 +12,7 @@ from datetime import date, datetime
 from email.utils import format_datetime
 from mimetypes import guess_type
 from pathlib import Path
-from typing import Iterable, Tuple
+from typing import Iterable, Optional, Tuple
 from urllib import request
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode, urlparse, urlunparse
@@ -58,7 +58,9 @@ class Util:
         self,
         path: str = ".",
         use_git: bool = True,
-        integration_material_social_cards: IntegrationMaterialSocialCards | None = None,
+        integration_material_social_cards: Optional[
+            IntegrationMaterialSocialCards
+        ] = None,
     ):
         """Class hosting the plugin logic.
 
@@ -478,7 +480,7 @@ class Util:
         else:
             return description if description else ""
 
-    def get_image(self, in_page: Page, base_url: str) -> tuple[str, str, int] | None:
+    def get_image(self, in_page: Page, base_url: str) -> Optional[tuple[str, str, int]]:
         """Get page's image from page meta or social cards and returns properties.
 
         Args:
@@ -487,7 +489,7 @@ class Util:
                 with local path.
 
         Returns:
-            tuple[str, str, int] | None: (image url, mime type, image length) or None if
+            Optional[tuple[str, str, int]]: (image url, mime type, image length) or None if
                 there is no image set
         """
         if in_page.meta.get("image"):

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,6 +4,6 @@
 # -------
 
 feedparser>=6.0,<6.1
-mkdocs-material>=9
+mkdocs-material[imaging]>=9
 pytest-cov>=4,<4.2
 validator-collection>=1.5,<1.6

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ def load_requirements(requirements_files: Union[Path, List[Path]]) -> list:
     """Helper to load requirements list from a path or a list of paths.
 
     Args:
-        requirements_files (Path | list[Path]): path or list to paths of requirements
-            file(s)
+        requirements_files (Union[Path, List[Path]]): path or list to paths of
+            requirements file(s)
 
     Returns:
         list: list of requirements loaded from file(s)

--- a/tests/fixtures/mkdocs_item_image_social_cards_enabled_site.yml
+++ b/tests/fixtures/mkdocs_item_image_social_cards_enabled_site.yml
@@ -1,0 +1,12 @@
+site_name: Test RSS Plugin
+site_description: Test a language code set in with territory
+site_url: https://guts.github.io/mkdocs-rss-plugin
+
+plugins:
+    - rss
+    - social:
+        enabled: true
+        cards: true
+
+theme:
+    name: material

--- a/tests/fixtures/mkdocs_item_image_social_enabled_but_cards_disabled.yml
+++ b/tests/fixtures/mkdocs_item_image_social_enabled_but_cards_disabled.yml
@@ -1,0 +1,12 @@
+site_name: Test RSS Plugin
+site_description: Test a language code set in with territory
+site_url: https://guts.github.io/mkdocs-rss-plugin
+
+plugins:
+    - rss
+    - social:
+        enabled: true
+        cards: false
+
+theme:
+    name: material

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,6 +72,7 @@ class TestConfig(BaseTest):
             "pretty_print": False,
             "url_parameters": None,
             "use_git": True,
+            "use_material_social_cards": True,
         }
 
         # load
@@ -99,6 +100,7 @@ class TestConfig(BaseTest):
             "pretty_print": False,
             "url_parameters": None,
             "use_git": True,
+            "use_material_social_cards": True,
         }
 
         # custom config

--- a/tests/test_integrations_material_social_cards.py
+++ b/tests/test_integrations_material_social_cards.py
@@ -1,0 +1,114 @@
+#! python3  # noqa E265
+
+"""Usage from the repo root folder:
+
+    .. code-block:: python
+
+        # for whole test
+        python -m unittest tests.test_build
+
+"""
+
+# #############################################################################
+# ########## Libraries #############
+# ##################################
+
+# Standard library
+import tempfile
+import unittest
+from logging import DEBUG, getLogger
+from pathlib import Path
+from traceback import format_exception
+
+# 3rd party
+import feedparser
+from mkdocs.config import load_config
+
+# package
+from mkdocs_rss_plugin.integrations.theme_material_social_plugin import (
+    IntegrationMaterialSocialCards,
+)
+
+# test suite
+from tests.base import BaseTest
+
+# #############################################################################
+# ########## Classes ###############
+# ##################################
+
+logger = getLogger(__name__)
+logger.setLevel(DEBUG)
+
+
+class TestRssPluginIntegrationsMaterialSocialCards(BaseTest):
+    """Test integration of Social Cards plugin with RSS plugin."""
+
+    # -- TESTS ---------------------------------------------------------
+    def test_plugin_config_social_cards_enabled(self):
+        # default reference
+        cfg_mkdocs = load_config(
+            str(
+                Path(
+                    "tests/fixtures/mkdocs_item_image_social_cards_enabled_site.yml"
+                ).resolve()
+            )
+        )
+
+        integration_social_cards = IntegrationMaterialSocialCards(
+            mkdocs_config=cfg_mkdocs
+        )
+        self.assertTrue(integration_social_cards.IS_THEME_MATERIAL)
+        self.assertTrue(integration_social_cards.IS_SOCIAL_PLUGIN_ENABLED)
+        self.assertTrue(integration_social_cards.IS_SOCIAL_PLUGIN_CARDS_ENABLED)
+        self.assertTrue(integration_social_cards.IS_ENABLED)
+
+    def test_plugin_config_social_plugin_enabled_but_cards_disabled(self):
+        # default reference
+        cfg_mkdocs = load_config(
+            str(
+                Path(
+                    "tests/fixtures/mkdocs_item_image_social_enabled_but_cards_disabled.yml"
+                ).resolve()
+            )
+        )
+
+        integration_social_cards = IntegrationMaterialSocialCards(
+            mkdocs_config=cfg_mkdocs
+        )
+        self.assertTrue(integration_social_cards.IS_THEME_MATERIAL)
+        self.assertTrue(integration_social_cards.IS_SOCIAL_PLUGIN_ENABLED)
+        self.assertFalse(integration_social_cards.IS_SOCIAL_PLUGIN_CARDS_ENABLED)
+        self.assertFalse(integration_social_cards.IS_ENABLED)
+
+    def test_simple_build(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            cli_result = self.build_docs_setup(
+                testproject_path="docs",
+                mkdocs_yml_filepath=Path(
+                    "tests/fixtures/mkdocs_item_image_social_cards_enabled_site.yml"
+                ),
+                output_path=tmpdirname,
+                strict=False,
+            )
+
+            if cli_result.exception is not None:
+                e = cli_result.exception
+                logger.debug(format_exception(type(e), e, e.__traceback__))
+
+            self.assertEqual(cli_result.exit_code, 0)
+            self.assertIsNone(cli_result.exception)
+
+            # created items
+            feed_parsed = feedparser.parse(Path(tmpdirname) / "feed_rss_created.xml")
+            self.assertEqual(feed_parsed.bozo, 0)
+
+            # updated items
+            feed_parsed = feedparser.parse(Path(tmpdirname) / "feed_rss_updated.xml")
+            self.assertEqual(feed_parsed.bozo, 0)
+
+
+# ##############################################################################
+# ##### Stand alone program ########
+# ##################################
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_rss_util.py
+++ b/tests/test_rss_util.py
@@ -72,7 +72,7 @@ class TestRssUtil(unittest.TestCase):
     def test_local_image_ok(self):
         """Test local image length calculation."""
         img_length = self.plg_utils.get_local_image_length(
-            page_path="docs/index.md", path_to_append="rss_icon.svg"
+            page_path="docs/index.md", path_to_append="assets/rss_icon.svg"
         )
         self.assertIsInstance(img_length, int)
 


### PR DESCRIPTION
This PR adds logic and option to support Social Cards of Material theme out-of-the-box.

## Functional

- [x] if a page has no image set but social cards is enabled, use the generated image as item's image
- [x] option to enable/disable this integration in `mkdocs.plugins.rss`

## Before/after

Considering the RSS feed from this plugin documentation: <https://guts.github.io/mkdocs-rss-plugin/integrations/>

### Before

```xml
<item>
  <title>Integrations</title>
  <description>&lt;h2&gt;Reference RSS feeds in HTML meta-tags&lt;/h2&gt;
&lt;p&gt;To facilitate the discovery of RSS feeds, it&#39;s recommended to add relevant meta-tags in &lt;code&gt;&amp;lt;head&amp;gt;&lt;/code&gt; section in HTML pa...&lt;/p&gt;</description>
  <link>https://guts.github.io/mkdocs-rss-plugin/integrations/?utm_source=documentation&amp;utm_medium=RSS&amp;utm_campaign=feed-syndication</link>
  <pubDate>Tue, 12 Dec 2023 11:02:08 +0100</pubDate>
  <source url="https://guts.github.io/mkdocs-rss-plugin/feed_rss_created.xml">MkDocs RSS Plugin</source>
  <guid isPermaLink="true">https://guts.github.io/mkdocs-rss-plugin/integrations/</guid>
</item>
```

### After

```xml
<item>
    <title>Integrations</title>
    <description>
    <h2>Social Cards plugin (from Material theme)</h2> <p>Since version 1.10, the plugin integrates with the [Social Cards plugin (shipped with Material theme)](https://...</p>
    </description>
    <link>
    http://127.0.0.1:8000/mkdocs-rss-plugin/integrations/?utm_source=documentation&utm_medium=RSS&utm_campaign=feed-syndication
    </link>
    <pubDate>Tue, 12 Dec 2023 12:02:08 +0100</pubDate>
    <source url="http://127.0.0.1:8000/mkdocs-rss-plugin/feed_rss_created.xml">MkDocs RSS Plugin</source>
    <guid isPermaLink="true">
    http://127.0.0.1:8000/mkdocs-rss-plugin/integrations/
    </guid>
    <enclosure url="https://guts.github.io/mkdocs-rss-plugin/assets/images/social/integrations.png" type="image/png" length="46533"/>
</item>
```

See the last `enclosure` line.

## Resources

- related section about Social Cards in Material documentation: <https://squidfunk.github.io/mkdocs-material/setup/setting-up-social-cards/>