### PR TITLE
docs: fix indentation of nested lists

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,7 +74,7 @@ For JSON Feed, you can use the icon:
 
 - Plugin logic is inspired from [Tim Vink git-based plugins](https://github.com/timvink?tab=repositories&q=mkdocs-git&type=&language=) and main parts of Git stuff are nearly copied/pasted.
 - Using magic mainly from:
-  - [GitPython](https://gitpython.readthedocs.io/)
-  - [Jinja2](https://jinja.palletsprojects.com/)
+    - [GitPython](https://gitpython.readthedocs.io/)
+    - [Jinja2](https://jinja.palletsprojects.com/)
 - Documentation colors are a tribute to the classic RSS color scheme: orange and white.
 - Logo generated with DALL·E.


### PR DESCRIPTION
Nested lists require 4 spaces of indent in Python Markdown, which differs from GitHub Flavored Markdown.

This PR fixes the indent in https://guts.github.io/mkdocs-rss-plugin/#credits.

Relates-to: https://github.com/Python-Markdown/markdown/issues/3

Besides, `rg '  -' ./docs/ --type=md --context 5` finds another nested list, but its indentation is correct.

https://github.com/Guts/mkdocs-rss-plugin/blob/8935f6c6552e7b7eec19828b2f24473ebe05f3ca/docs/configuration.md#L416-L418
