### PR TITLE
Update docs on locale configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,7 +30,7 @@ To produce a valid RSS feed, the plugin uses:
 | [`site_author`](https://www.mkdocs.org/user-guide/configuration/#site_author) | **recommended** | [`managingEditor`](https://www.w3schools.com/xml/rss_tag_managingeditor.asp) |
 | ---- | ---- | ---- |
 | [`copyright`](https://www.mkdocs.org/user-guide/configuration/#copyright) | *optional* | [`copyright`](https://www.w3schools.com/xml/rss_tag_copyright.asp) |
-| [`locale` or `theme/locale` or `theme/language`](https://github.com/squidfunk/mkdocs-material/issues/1350#issuecomment-559095892) | *optional* | [`language`](https://www.w3schools.com/xml/rss_tag_language.asp) |
+| [`theme/locale` (or `theme/language` for Material theme)](https://github.com/squidfunk/mkdocs-material/issues/1350#issuecomment-559095892) | *optional* | [`language`](https://www.w3schools.com/xml/rss_tag_language.asp) |
 
 ### Automatic elements
 


### PR DESCRIPTION
`locale` at root was deprecated in #212, and `theme/language` only works for Material theme.

Relevant implementation:

https://github.com/Guts/mkdocs-rss-plugin/blob/15938261138769919c714e60d4925c58bffa81e1/mkdocs_rss_plugin/util.py#L720-L723