### PR TITLE
ci: use trusted publisher and remove token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,6 @@ jobs:
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
           print-hash: true
 
       - name: Create/update release on GitHub


### PR DESCRIPTION
Upstream reference: https://docs.pypi.org/trusted-publishers/