### PR TITLE
feature: allow multiple instances

### DIFF
--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -51,6 +51,9 @@ logger = get_plugin_logger(MKDOCS_LOGGER_NAME)
 class GitRssPlugin(BasePlugin[RssPluginConfig]):
     """Main class for MkDocs plugin."""
 
+    # allow to set the plugin multiple times in the same mkdocs config
+    supports_multiple_instances = True
+
     def __init__(self):
         """Instanciation."""
         # dates source

--- a/tests/dev/dev_load_config.py
+++ b/tests/dev/dev_load_config.py
@@ -1,0 +1,20 @@
+from mkdocs.config import load_config
+
+from mkdocs_rss_plugin.plugin import GitRssPlugin
+
+mkdocs_cfg = load_config(config_file="tests/fixtures/mkdocs_multiple_instances.yml")
+
+print(mkdocs_cfg.plugins.keys())
+rss_instances = [
+    plg for plg in mkdocs_cfg.plugins.items() if isinstance(plg[1], GitRssPlugin)
+]
+print(len(rss_instances))
+
+for plg in mkdocs_cfg.plugins.items():
+    print(plg)
+    print(isinstance(plg[1], GitRssPlugin))
+    print(type(plg))
+
+rss_instance_1 = plg[1]
+print(dir(rss_instance_1))
+print(rss_instance_1.on_config(mkdocs_cfg))

--- a/tests/fixtures/docs/blog/posts/sample_blog_post.md
+++ b/tests/fixtures/docs/blog/posts/sample_blog_post.md
@@ -1,6 +1,7 @@
 ---
 date: 2023-02-12
-authors: [guts]
+authors:
+  - guts
 categories:
   - Blog
 ---

--- a/tests/fixtures/mkdocs_multiple_instances.yml
+++ b/tests/fixtures/mkdocs_multiple_instances.yml
@@ -1,0 +1,16 @@
+site_name: Test Mkdocs with multiple RSS plugin instances
+site_description: Multiple RSS plugin in a single mkdocs
+site_url: https://guts.github.io/mkdocs-rss-plugin
+
+plugins:
+  - rss
+  - rss:
+      feeds_filenames:
+        json_created: blog.json
+        json_updated: blog-updated.json
+        rss_created: blog.xml
+        rss_updated: blog-updated.xml
+      match_path: "blog/.*"
+
+theme:
+  name: material

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -564,6 +564,51 @@ class TestBuildRss(BaseTest):
             )
             self.assertEqual(feed_parsed.bozo, 0)
 
+    def test_simple_build_multiple_instances(self):
+        config = self.get_plugin_config_from_mkdocs(
+            mkdocs_yml_filepath=Path("tests/fixtures/mkdocs_multiple_instances.yml"),
+            plugin_name="rss",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            cli_result = self.build_docs_setup(
+                testproject_path="docs",
+                mkdocs_yml_filepath=Path(
+                    "tests/fixtures/mkdocs_multiple_instances.yml"
+                ),
+                output_path=tmpdirname,
+                strict=True,
+            )
+
+            if cli_result.exception is not None:
+                e = cli_result.exception
+                logger.debug(format_exception(type(e), e, e.__traceback__))
+
+            self.assertEqual(cli_result.exit_code, 0)
+            self.assertIsNone(cli_result.exception)
+
+            # created items
+            feed_parsed = feedparser.parse(
+                Path(tmpdirname) / config.feeds_filenames.rss_created
+            )
+            self.assertEqual(feed_parsed.bozo, 0)
+
+            # updated items
+            feed_parsed = feedparser.parse(
+                Path(tmpdirname) / config.feeds_filenames.rss_updated
+            )
+            self.assertEqual(feed_parsed.bozo, 0)
+
+            # created items - blog
+            feed_parsed = feedparser.parse(Path(tmpdirname).joinpath("blog.xml"))
+            self.assertEqual(feed_parsed.bozo, 0)
+
+            # updated items - blog
+            feed_parsed = feedparser.parse(
+                Path(tmpdirname).joinpath("blog-updated.xml")
+            )
+            self.assertEqual(feed_parsed.bozo, 0)
+
     def test_simple_build_pretty_print_enabled(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             cli_result = self.build_docs_setup(


### PR DESCRIPTION
It's now possible to have a mkdocs.yml like this:

```yaml
plugins:
  - rss
  - rss:
      feeds_filenames:
        json_created: blog.json
        json_updated: blog-updated.json
        rss_created: blog.xml
        rss_updated: blog-updated.xml
      match_path: "blog/.*"
```

Closes #219