### PR TITLE
Make match_path OS agnostic

### DIFF
--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -275,7 +275,7 @@ class GitRssPlugin(BasePlugin[RssPluginConfig]):
             return
 
         # skip pages that don't match the config var match_path
-        if not self.match_path_pattern.match(page.file.src_path):
+        if not self.match_path_pattern.match(page.file.src_uri):
             return
 
         # skip pages with draft=true


### PR DESCRIPTION
`page.file.src_path` on Windows contains backslashes resulting in an empty RSS feed if `match_path` contains a forward slash. This commit replaces `src_path` with `src_uri` which provides an OS independent path with forward slashes '/'.

fixes #321