### PR TITLE
fix(rss): email and name were inverted in output and so uncompliant

### DIFF
--- a/mkdocs_rss_plugin/integrations/theme_material_blog_plugin.py
+++ b/mkdocs_rss_plugin/integrations/theme_material_blog_plugin.py
@@ -124,7 +124,7 @@ class IntegrationMaterialBlog(IntegrationMaterialThemeBase):
             if author_id in self.blog_plugin_cfg.authors:
                 author_metadata = self.blog_plugin_cfg.authors.get(author_id)
                 if "email" in self.blog_plugin_cfg.authors.get(author_id):
-                    return f"{author_metadata.get('name')} ({author_metadata.get('email')})"
+                    return f"{author_metadata.get('email')} ({author_metadata.get('name')})"
                 else:
                     return author_metadata.get("name")
             else:


### PR DESCRIPTION
Related to: https://github.com/Guts/mkdocs-rss-plugin/issues/250
See: https://validator.w3.org/feed/docs/error/InvalidContact.html

Before:

```xml
<author>John Doe (John.Doe@example.com)</author>
```

After:


```xml
<author>John.Doe@example.com (John Doe)</author>
```

cc @stefansli