### PR TITLE
fix(material_social): use cards_dir to build cards url for page

### DIFF
--- a/tests/fixtures/mkdocs_item_image_social_cards_blog_directory_url_disabled.yml
+++ b/tests/fixtures/mkdocs_item_image_social_cards_blog_directory_url_disabled.yml
@@ -1,0 +1,18 @@
+site_name: Test RSS Plugin with social cards, blog plugin and directory URL disabled
+site_description: Test RSS with social and blog plugins enabled but directory URLS disabled. Related to https://github.com/Guts/mkdocs-rss-plugin/issues/319.
+site_url: https://guts.github.io/mkdocs-rss-plugin
+
+use_directory_urls: false
+
+plugins:
+    - blog:
+          blog_dir: blog
+          authors_profiles: true
+    - rss:
+          match_path: blog/posts/.*
+    - social:
+          enabled: true
+          cards: true
+
+theme:
+    name: material


### PR DESCRIPTION
This should fix #319 

The path building is based on https://github.com/squidfunk/mkdocs-material/blob/396c493f4774fa0bafeada5d0b555d02193557e8/src/plugins/social/plugin.py#L339-L362