### PR TITLE
fix(upstream): force jsonfeed-util version since it uses a non Python 3.9 syntax, breaking lint and tests

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,7 +4,7 @@
 # -------
 
 feedparser>=6.0.11,<6.1
-jsonfeed-util>=1.1.2,<2
+jsonfeed-util>=1.1.2,<1.1.4
 mkdocs-material[imaging]>=9.5.47
 pytest-cov>=6,<7
 validator-collection>=1.5,<1.6


### PR DESCRIPTION


see: https://github.com/lukasschwab/jsonfeed/issues/15