### PR TITLE
fix: return None if remote image length is unavailable

### DIFF
--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -587,19 +587,13 @@ class Util:
             img_url = self.social_cards.get_social_card_url_for_page(
                 mkdocs_page=in_page
             )
-            if (
-                img_local_cache_path
-                := self.social_cards.get_social_card_cache_path_for_page(
-                    mkdocs_page=in_page
-                )
+            if img_local_cache_path := self.social_cards.get_social_card_cache_path_for_page(
+                mkdocs_page=in_page
             ):
                 img_length = img_local_cache_path.stat().st_size
                 img_type = guess_type(url=img_local_cache_path, strict=False)[0]
-            elif (
-                img_local_build_path
-                := self.social_cards.get_social_card_build_path_for_page(
-                    mkdocs_page=in_page
-                )
+            elif img_local_build_path := self.social_cards.get_social_card_build_path_for_page(
+                mkdocs_page=in_page
             ):
                 img_length = img_local_build_path.stat().st_size
                 img_type = guess_type(url=img_local_build_path, strict=False)[0]

--- a/mkdocs_rss_plugin/util.py
+++ b/mkdocs_rss_plugin/util.py
@@ -126,8 +126,7 @@ class Util:
         else:
             self.git_is_valid = False
             logger.debug(
-                "Git use is disabled. "
-                "Only page.meta (YAML frontmatter will be used). "
+                "Git use is disabled. Only page.meta (YAML frontmatter will be used). "
             )
 
         # save git enable/disable status
@@ -588,13 +587,19 @@ class Util:
             img_url = self.social_cards.get_social_card_url_for_page(
                 mkdocs_page=in_page
             )
-            if img_local_cache_path := self.social_cards.get_social_card_cache_path_for_page(
-                mkdocs_page=in_page
+            if (
+                img_local_cache_path
+                := self.social_cards.get_social_card_cache_path_for_page(
+                    mkdocs_page=in_page
+                )
             ):
                 img_length = img_local_cache_path.stat().st_size
                 img_type = guess_type(url=img_local_cache_path, strict=False)[0]
-            elif img_local_build_path := self.social_cards.get_social_card_build_path_for_page(
-                mkdocs_page=in_page
+            elif (
+                img_local_build_path
+                := self.social_cards.get_social_card_build_path_for_page(
+                    mkdocs_page=in_page
+                )
             ):
                 img_length = img_local_build_path.stat().st_size
                 img_type = guess_type(url=img_local_build_path, strict=False)[0]
@@ -707,7 +712,7 @@ class Util:
                 )
                 return None
 
-        return int(img_length)
+        return int(img_length) if img_length else None
 
     @staticmethod
     def get_site_url(mkdocs_config: MkDocsConfig) -> Optional[str]:


### PR DESCRIPTION
When this plugin is run on a doc site that also uses the social plugin, fetching remote image data can fail. This results in a crash when building the documentation:

      File "/path/installs/python/3.11.5/lib/python3.11/site-packages/mkdocs_rss_plugin/util.py", line 608, in get_image
        img_length = self.get_remote_image_length(image_url=img_url)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/path/installs/python/3.11.5/lib/python3.11/site-packages/mkdocs_rss_plugin/util.py", line 710, in get_remote_image_length
        return int(img_length)
               ^^^^^^^^^^^^^^^
    TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'

This patch simply returns None if `img_length` is `None.`

Closes: #369
Closes: #353