### PR TITLE
fix: preserve sentence structure across newlines

### DIFF
--- a/mkdocs_rss_plugin/plugin.py
+++ b/mkdocs_rss_plugin/plugin.py
@@ -432,7 +432,8 @@ class GitRssPlugin(BasePlugin[RssPluginConfig]):
                     prev_char = ""
                     for char in template.render(feed=asdict(self.feed_created)):
                         if char == "\n":
-                            continue
+                            # convert new lines to spaces to preserve sentence structure
+                            char = " "
                         if char == " " and prev_char == " ":
                             prev_char = char
                             continue
@@ -442,8 +443,8 @@ class GitRssPlugin(BasePlugin[RssPluginConfig]):
                 with out_feed_updated.open(mode="w", encoding="UTF8") as fifeed_updated:
                     for char in template.render(feed=asdict(self.feed_updated)):
                         if char == "\n":
-                            prev_char = char
-                            continue
+                            # convert new lines to spaces to preserve sentence structure
+                            char = " "
                         if char == " " and prev_char == " ":
                             prev_char = char
                             continue

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -405,6 +405,12 @@ class TestBuildRss(BaseTest):
                         150,
                         f"Failed item title: {feed_item.title}",
                     )
+                # check sentences split across multiple lines retain spacing
+                if feed_item.title in ["My first blog post", "A second post"]:
+                    self.assertIn(
+                        "Pellentesque nec maximus ex.",
+                        feed_item.summary,
+                    )
 
     def test_simple_build_item_delimiter(self):
         with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
Instead of stripping out the newlines characters, leading to mangled content when rendering full contents, provide a space instead.

Fixes #186